### PR TITLE
Avoid redirecting deep-links to home while directory data loads

### DIFF
--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -28,8 +28,19 @@ const itemVariants = {
 
 export default function CategoryPage() {
   const { cityId, categoryId } = useParams<{ cityId: string, categoryId: string }>();
-  const { cities, categories, businesses } = useDirectoryData();
+  const { cities, categories, businesses, isLoading } = useDirectoryData();
   const [sortBy, setSortBy] = useState('Highest Rated');
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA] px-6">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">Loading category</p>
+        </div>
+      </div>
+    );
+  }
   
   const city = cities.find(c => c.id === cityId);
   const category = categories.find(c => c.id === categoryId);

--- a/src/pages/CityPage.tsx
+++ b/src/pages/CityPage.tsx
@@ -27,7 +27,19 @@ const itemVariants = {
 
 export default function CityPage() {
   const { cityId } = useParams<{ cityId: string }>();
-  const { cities, categories, businesses } = useDirectoryData();
+  const { cities, categories, businesses, isLoading } = useDirectoryData();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA] px-6">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">Loading city</p>
+        </div>
+      </div>
+    );
+  }
+
   const city = cities.find(c => c.id === cityId);
 
   if (!city) {


### PR DESCRIPTION
### Motivation
- Deep-linked URLs like `/:cityId` and `/:cityId/:categoryId` were falling through to the homepage because the app redirected before the directory data finished loading. 
- The goal is to preserve valid deep-link behavior after the server rewrite by showing a loading state until `useDirectoryData()` is ready.

### Description
- Add an `isLoading` guard to `CategoryPage` to render a centered loading state while directory data is being fetched. 
- Add the same `isLoading` guard to `CityPage` to prevent premature `Navigate to "/"` redirects for valid city pages. 
- Keep the existing redirect to `/` for truly invalid city/category paths after loading completes.

### Testing
- Ran `npm run lint` (TypeScript checks) which succeeded. 
- Ran `npm run build` (Vite production build) which succeeded. 
- Attempted an automated Playwright render check to capture a screenshot, but the Chromium process crashed (SIGSEGV) in this environment and the capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39a407e2c83209cbea03f18ae18a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Improvements**
  * Added loading indicators with spinners that display while category and city data are being fetched, providing better feedback during load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->