### PR TITLE
Add loading state and simplify business filtering on City and Category pages

### DIFF
--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link, Navigate } from 'react-router-dom';
 import { MapPin, ArrowRight, Search } from 'lucide-react';
 import * as Icons from 'lucide-react';
@@ -28,8 +28,19 @@ const itemVariants = {
 
 export default function CategoryPage() {
   const { cityId, categoryId } = useParams<{ cityId: string, categoryId: string }>();
-  const { cities, categories, businesses } = useDirectoryData();
+  const { cities, categories, businesses, isLoading } = useDirectoryData();
   const [sortBy, setSortBy] = useState('Highest Rated');
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA] px-6">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">Loading category</p>
+        </div>
+      </div>
+    );
+  }
   
   const city = cities.find(c => c.id === cityId);
   const category = categories.find(c => c.id === categoryId);
@@ -38,23 +49,21 @@ export default function CategoryPage() {
     return <Navigate to="/" replace />;
   }
 
-  const categoryBusinesses = useMemo(() => {
-    const filtered = businesses.filter(
-      (business) => business.categoryId === categoryId && businessServesCity(business, city.id, city.name)
-    ) as Business[];
+  const filteredBusinesses = businesses.filter(
+    (business) => business.categoryId === categoryId && businessServesCity(business, city.id, city.name)
+  ) as Business[];
 
-    return [...filtered].sort((left, right) => {
-      if (sortBy === 'Most Reviewed') {
-        return (right.reviewCount ?? 0) - (left.reviewCount ?? 0);
-      }
+  const categoryBusinesses = [...filteredBusinesses].sort((left, right) => {
+    if (sortBy === 'Most Reviewed') {
+      return (right.reviewCount ?? 0) - (left.reviewCount ?? 0);
+    }
 
-      if (sortBy === 'A-Z') {
-        return left.name.localeCompare(right.name);
-      }
+    if (sortBy === 'A-Z') {
+      return left.name.localeCompare(right.name);
+    }
 
-      return (right.rating ?? 0) - (left.rating ?? 0) || (right.reviewCount ?? 0) - (left.reviewCount ?? 0);
-    });
-  }, [businesses, categoryId, cityId, sortBy]);
+    return (right.rating ?? 0) - (left.rating ?? 0) || (right.reviewCount ?? 0) - (left.reviewCount ?? 0);
+  });
 
   const IconComponent = (Icons as any)[category.icon] || Icons.Wrench;
   const heroImage = getCategoryHeroImage({

--- a/src/pages/CityPage.tsx
+++ b/src/pages/CityPage.tsx
@@ -27,7 +27,19 @@ const itemVariants = {
 
 export default function CityPage() {
   const { cityId } = useParams<{ cityId: string }>();
-  const { cities, categories, businesses } = useDirectoryData();
+  const { cities, categories, businesses, isLoading } = useDirectoryData();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA] px-6">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-zinc-500">Loading city</p>
+        </div>
+      </div>
+    );
+  }
+
   const city = cities.find(c => c.id === cityId);
 
   if (!city) {


### PR DESCRIPTION
### Motivation

- Provide a user-friendly loading state while directory data is being fetched to avoid blank pages. 
- Simplify and clarify the category business filtering/sorting logic by removing an unnecessary `useMemo` and making intermediate variables explicit.

### Description

- Added `isLoading` handling from `useDirectoryData` and render a centered spinner/label UI while data loads in `CityPage.tsx` and `CategoryPage.tsx`.
- Removed the unused `useMemo` import and replaced the memoized category business computation with a clearer two-step process using `filteredBusinesses` and `categoryBusinesses` in `CategoryPage.tsx`.
- Kept existing sort behavior (`Most Reviewed`, `A-Z`, default by rating then review count) and preserved hero/icon logic; no changes to business-serving checks.

### Testing

- Ran `yarn test` (project unit tests) and they passed.
- Ran `yarn lint` and the linter passed without issues.
- Built the app with `yarn build` to ensure typechecks and production bundle succeed and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b39a407e2c83209cbea03f18ae18a2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators displayed on category and city pages during data retrieval
  * Enhanced data loading experience with dedicated loading state management
  * Pages now ensure complete data availability before rendering dependent features
  * Sorting and filtering functionality continues to work as expected
  * Improved overall reliability of data loading process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->