### PR TITLE
Add Supabase magic link authentication support

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,6 +21,7 @@ interface AuthContextType {
   error: string | null;
   isConfigured: boolean;
   signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
+  signInWithMagicLink: (email: string, redirectPath?: string) => Promise<{ error: Error | null }>;
   signInWithGoogle: (redirectPath?: string) => Promise<{ error: Error | null }>;
   signUp: (
     email: string,
@@ -265,6 +266,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const signInWithMagicLink = async (email: string, redirectPath = '/account') => {
+    if (!supabase) {
+      return { error: new Error('Supabase not configured') };
+    }
+
+    try {
+      setError(null);
+
+      const safeRedirectPath = redirectPath.startsWith('/') ? redirectPath : '/account';
+      const emailRedirectTo = new URL(safeRedirectPath, window.location.origin).toString();
+      const { error: magicLinkError } = await supabase.auth.signInWithOtp({
+        email: email.trim().toLowerCase(),
+        options: {
+          emailRedirectTo,
+        },
+      });
+
+      if (magicLinkError) {
+        setError(magicLinkError.message);
+      }
+
+      return { error: magicLinkError };
+    } catch (magicLinkError) {
+      const normalizedError = magicLinkError instanceof Error ? magicLinkError : new Error('Unable to send a magic link right now.');
+      setError(normalizedError.message);
+      return { error: normalizedError };
+    }
+  };
+
   const signOut = async () => {
     if (!supabase) {
       return;
@@ -290,6 +320,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         error,
         isConfigured: configured,
         signIn,
+        signInWithMagicLink,
         signInWithGoogle,
         signUp,
         signOut,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,16 +1,17 @@
 import { type FormEvent, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { ArrowRight, ShieldCheck, Zap } from 'lucide-react';
+import { ArrowRight, MailCheck, ShieldCheck } from 'lucide-react';
 import { motion } from 'motion/react';
 import GoogleIcon from '../components/GoogleIcon';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { user, loading: authLoading, error: authError, isConfigured, signIn, signInWithGoogle } = useAuth();
+  const { user, loading: authLoading, error: authError, isConfigured, signIn, signInWithGoogle, signInWithMagicLink } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -27,6 +28,7 @@ export default function LoginPage() {
     }
 
     setError(null);
+    setMagicLinkSent(false);
     setLoading(true);
 
     const { error } = await signIn(email, password);
@@ -39,12 +41,41 @@ export default function LoginPage() {
     }
   };
 
+
+
+  const handleMagicLinkSignIn = async () => {
+    if (authLoading || !isConfigured) {
+      return;
+    }
+
+    if (!email.trim()) {
+      setError('Enter your email to get a secure sign-in link.');
+      return;
+    }
+
+    setError(null);
+    setMagicLinkSent(false);
+    setLoading(true);
+
+    const { error: magicLinkError } = await signInWithMagicLink(email, '/account');
+
+    if (magicLinkError) {
+      setError(magicLinkError.message);
+      setLoading(false);
+      return;
+    }
+
+    setMagicLinkSent(true);
+    setLoading(false);
+  };
+
   const handleGoogleSignIn = async () => {
     if (authLoading || !isConfigured) {
       return;
     }
 
     setError(null);
+    setMagicLinkSent(false);
     setLoading(true);
 
     const { error } = await signInWithGoogle('/account');
@@ -83,6 +114,13 @@ export default function LoginPage() {
 
         <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.1 }} className="bg-white border border-zinc-200 p-8 sm:p-12 rounded-sm shadow-xl text-left relative z-10">
           <div className="space-y-6">
+            {magicLinkSent && (
+              <div className="bg-emerald-50 border border-emerald-200 text-emerald-700 rounded-xl px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-widest inline-flex items-center gap-2">
+                <MailCheck className="w-4 h-4" />
+                Magic link sent. Check your inbox to continue.
+              </div>
+            )}
+
             {visibleError && (
               <div className="bg-red-50 border border-red-200 text-red-600 rounded-xl px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-widest">
                 {visibleError}
@@ -138,9 +176,21 @@ export default function LoginPage() {
               />
             </div>
 
-            <div className="pt-6">
-              <button 
-                type="submit" 
+            <div className="pt-2">
+              <button
+                type="button"
+                onClick={handleMagicLinkSignIn}
+                disabled={loading || authLoading || !isConfigured}
+                className="w-full inline-flex items-center justify-center gap-3 bg-zinc-100 text-zinc-900 border border-zinc-200 rounded-xl px-8 py-4 font-sans text-sm font-semibold uppercase tracking-widest transition-all shadow-sm hover:bg-zinc-200 hover:-translate-y-1 hover:shadow-md active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+              >
+                <MailCheck className="h-5 w-5" strokeWidth={2.5} />
+                {loading ? 'Sending magic link...' : 'Email Me a Magic Link'}
+              </button>
+            </div>
+
+            <div className="pt-1">
+              <button
+                type="submit"
                 disabled={loading || authLoading || !isConfigured}
                 className="w-full inline-flex items-center justify-center gap-3 bg-zinc-900 text-white rounded-xl px-8 py-4 font-sans text-sm font-semibold uppercase tracking-widest transition-all shadow-sm hover:bg-orange-500 hover:-translate-y-1 hover:shadow-md active:scale-95 group disabled:opacity-50 disabled:pointer-events-none"
               >


### PR DESCRIPTION
### Motivation
- Provide a passwordless sign-in option using Supabase magic links to improve user onboarding and security.
- Allow configurable redirect paths after magic-link sign-in and unify error handling with existing auth flows.

### Description
- Added `signInWithMagicLink(email, redirectPath?)` to the auth context which calls `supabase.auth.signInWithOtp` with a sanitized redirect URL and shared error/state handling in `src/contexts/AuthContext.tsx`.
- Exposed the new method in the `AuthContext` interface and provider value so consumers can call it via `useAuth()`.
- Updated the login page `src/pages/LoginPage.tsx` to include a new "Email Me a Magic Link" button, a `handleMagicLinkSignIn` handler, `magicLinkSent` feedback state, and validation to require an email before sending the link.
- Added UI feedback for successful magic-link delivery and reset logic so switching between Google/password/magic-link flows clears prior feedback.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and it succeeded.
- Ran `npm run build` (Vite production build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44eba15448320af030ac945b42304)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added magic link authentication: Users can now sign in by entering their email address to receive a sign-in link.
  * Introduced dedicated "Email Me a Magic Link" option alongside existing password and Google sign-in methods.
  * Added confirmation banner when a magic link is successfully sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->