### PR TITLE
Add `inlineMode` ('pill' | 'bar') to MobileDirectorySearch and surface it in SearchPage header

### DIFF
--- a/src/components/MobileDirectorySearch.tsx
+++ b/src/components/MobileDirectorySearch.tsx
@@ -15,6 +15,7 @@ interface MobileDirectorySearchProps {
   initialQuery?: string;
   initialCityId?: string;
   inlineClassName?: string;
+  inlineMode?: 'pill' | 'bar';
 }
 
 const mobileSearchTransition = {
@@ -27,6 +28,7 @@ export default function MobileDirectorySearch({
   initialQuery = '',
   initialCityId = '',
   inlineClassName = '',
+  inlineMode = 'pill',
 }: MobileDirectorySearchProps) {
   const navigate = useNavigate();
   const { isMobileMenuOpen } = useLayoutChrome();
@@ -73,13 +75,19 @@ export default function MobileDirectorySearch({
 
   const compactSearchLabel = query.trim() || 'Search contractors';
   const selectedCityName = cities.find((city) => city.id === cityId)?.name ?? 'All Okanagan';
+  const inlineContainerClassName = inlineMode === 'bar'
+    ? 'mx-auto w-full max-w-7xl bg-zinc-50 px-4 py-3 sm:px-6 md:hidden lg:px-8'
+    : 'mx-auto w-full max-w-7xl px-4 pt-3 sm:px-6 md:hidden lg:px-8';
+  const inlineButtonClassName = inlineMode === 'bar'
+    ? 'flex w-full min-w-0 items-center gap-3 rounded-2xl border border-zinc-200/80 bg-white px-3 py-2.5 text-left shadow-[0_2px_10px_rgba(24,24,27,0.05)]'
+    : 'flex w-full min-w-0 items-center gap-3 rounded-[2rem] border border-zinc-200 bg-white px-4 py-3 text-left shadow-[0_8px_24px_rgba(24,24,27,0.08)]';
 
   return (
     <>
-      <div className={`mx-auto w-full max-w-7xl px-4 pt-3 sm:px-6 md:hidden lg:px-8 ${inlineClassName}`}>
+      <div className={`${inlineContainerClassName} ${inlineClassName}`}>
         <button
           type="button"
-          className="flex w-full min-w-0 items-center gap-3 rounded-[2rem] border border-zinc-200 bg-white px-4 py-3 text-left shadow-[0_8px_24px_rgba(24,24,27,0.08)]"
+          className={inlineButtonClassName}
           onClick={() => setIsMobileSearchOpen(true)}
           aria-label="Open mobile search"
         >

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -107,10 +107,16 @@ export default function SearchPage() {
       animate={{opacity: 1, y: 0}}
       exit={{opacity: 0, y: -20}}
       transition={{duration: 0.4, ease: 'easeOut'}}
-      className="bg-[#FAFAFA] min-h-screen py-16"
+      className="bg-[#FAFAFA] min-h-screen pt-0 pb-16"
     >
+      <MobileDirectorySearch
+        cities={cities}
+        initialQuery={rawQuery}
+        initialCityId={inferredCityId}
+        inlineMode="bar"
+        inlineClassName="border-b border-zinc-200"
+      />
       <Breadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Search' }]} />
-      <MobileDirectorySearch cities={cities} initialQuery={rawQuery} initialCityId={inferredCityId} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-12 border-b border-zinc-200 pb-6">
           <div className="inline-flex items-center gap-2 border border-zinc-200 bg-white text-zinc-600 px-3 py-1.5 font-mono text-[10px] tracking-[0.15em] mb-6 rounded-sm uppercase">


### PR DESCRIPTION
### Motivation
- Provide an alternate compact "bar" presentation for the mobile inline search so it can be embedded into page headers consistently.
- Surface the mobile search at the top of the `SearchPage` and adjust page spacing to accommodate the new header placement.

### Description
- Add an `inlineMode?: 'pill' | 'bar'` prop to `MobileDirectorySearch` with default `'pill'` and compute `inlineContainerClassName` and `inlineButtonClassName` based on the selected mode.
- Replace the hard-coded wrapper/button classes in `MobileDirectorySearch` with the new computed class names and preserve the existing `inlineClassName` prop for additional styling.
- Integrate `MobileDirectorySearch` into the top of `SearchPage` using `inlineMode="bar"` and `inlineClassName="border-b border-zinc-200"` and remove the previous duplicate placement.
- Adjust the `SearchPage` root padding from `py-16` to `pt-0 pb-16` to account for the newly placed inline search bar.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5107857ac832092354ffe67efb648)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile search component now supports a new bar-style display mode alongside the existing pill layout option
  * Search input repositioned above breadcrumbs on the search results page with adjusted spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->