### PR TITLE
Reduce Supabase businesses page size to speed Featured Operators load

### DIFF
--- a/src/directory-data.tsx
+++ b/src/directory-data.tsx
@@ -68,7 +68,7 @@ type BusinessOverrideRow = {
   photos: unknown;
 };
 
-const PAGE_SIZE = 1000;
+const PAGE_SIZE = 200;
 const ACTIVE_CITY_IDS = new Set([
   'kelowna',
   'vernon',


### PR DESCRIPTION
### Motivation
- The Featured Operators section depends on the full `businesses` payload and was loading very slowly or not at all when a single large Supabase `range(0,999)` request (with large JSON columns) was slow or timed out, so smaller fetch batches improve reliability.

### Description
- Lowered the Supabase pagination batch size by changing `PAGE_SIZE` from `1000` to `200` in `src/directory-data.tsx` to reduce per-request payload size for the `businesses` read.

### Testing
- Ran `npm run lint` (TypeScript check) and `npm run build` (production build via Vite) and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b2b23dcc832090f005d167705650)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized directory data pagination with refined batch sizing for improved retrieval efficiency. Enhanced request processing increases system responsiveness while maintaining all error handling mechanisms, data validation processes, and existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->