### PR TITLE
Hotfix production loading fallback

### DIFF
--- a/src/directory-data.tsx
+++ b/src/directory-data.tsx
@@ -106,10 +106,6 @@ function filterDirectoryData(data: DirectoryData): DirectoryData {
 let seedDataPromise: Promise<DirectoryData> | null = null;
 
 function loadSeedData() {
-  if (!import.meta.env.DEV) {
-    return Promise.reject(new Error('Static seed data is disabled in production builds.'));
-  }
-
   if (!seedDataPromise) {
     seedDataPromise = import('./data').then((module) => filterDirectoryData({
       cities: module.cities,

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -216,14 +216,6 @@ export default function BusinessPage() {
       setIsOwner(false);
 
       if (!supabase || !isSupabaseConfigured()) {
-        if (!import.meta.env.DEV) {
-          if (isActive) {
-            setLoadError('Listing data is unavailable because the backend is not configured.');
-            setIsLoading(false);
-          }
-          return;
-        }
-
         try {
           const module = await import('../data') as SeedDataModule;
           const seedBusiness = module.businesses.find((entry) => entry.id === businessId) ?? null;


### PR DESCRIPTION
## Summary
- apply post-merge fixes from review feedback (auth callback handling, business page ownership/load resilience, owner dashboard selection persistence)
- restore production seed fallback behavior so pages still render when Supabase reads fail or are unavailable
- keep existing claim-flow and dashboard improvements from the merged PR context while fixing live loading regressions

## Validation
- npm run lint
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Seed data now loads reliably across all environments, ensuring fallback data is available when the backend is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->