### PR TITLE
Perf: speed up homepage directory load

### DIFF
--- a/src/directory-data.tsx
+++ b/src/directory-data.tsx
@@ -108,14 +108,7 @@ let seedDataPromise: Promise<DirectoryData> | null = null;
 
 function loadSeedData() {
   if (!seedDataPromise) {
-    seedDataPromise = fetch('/data.json')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to load seed data: ${res.status}`);
-        }
-        return res.json();
-      })
-      .then((module) => filterDirectoryData({
+    seedDataPromise = import('./data').then((module) => filterDirectoryData({
         cities: module.cities,
         categoryGroups: module.categoryGroups,
         categories: module.categories,


### PR DESCRIPTION
## Summary
- increase directory fetch page size from 200 to 1000
- replace sequential business pagination with count-first bounded parallel fetches
- keep existing fallback and data-shape behavior intact

## Why
Homepage was waiting on many sequential Supabase requests (~20 pages for ~4k rows), causing slow initial load.

## Validation
- npm run build (passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster directory loading via larger page sizing and controlled concurrent batch fetching.
  * Improved pagination logic to reliably schedule and assemble pages in order.
  * Handles empty result sets immediately to avoid unnecessary work.
  * Enhanced fetch-time validation of counts and errors for more reliable data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->