### PR TITLE
feat: expose verifiedLookupDegraded flag for user-visible degraded state

### DIFF
--- a/src/directory-data.tsx
+++ b/src/directory-data.tsx
@@ -328,14 +328,15 @@ async function fetchDirectoryData(): Promise<DirectoryData> {
   ]);
 
   const overridesError = isMissingTableError(overrideRowsResult.error) ? null : overrideRowsResult.error;
-  const verifiedError = isMissingTableError(verifiedResult.error) ? null : verifiedResult.error;
+  const verifiedLookupError = verifiedResult.error;
+  const verifiedError = isMissingTableError(verifiedLookupError) ? null : verifiedLookupError;
   const firstError = citiesResult.error ?? groupResult.error ?? categoriesResult.error ?? overridesError;
   if (firstError) {
     throw new Error(firstError.message);
   }
 
-  if (verifiedError) {
-    console.warn('[directory-data] verified_businesses read failed; continuing without verified badges.', verifiedError);
+  if (verifiedLookupError) {
+    console.warn('[directory-data] verified_businesses read failed; continuing without verified badges.', verifiedLookupError);
   }
 
   const overridesByBusinessId = new Map(
@@ -343,12 +344,12 @@ async function fetchDirectoryData(): Promise<DirectoryData> {
   );
   
   const verifiedBusinessIds = new Set(
-    verifiedError
+    verifiedLookupError
       ? []
       : ((verifiedResult.data ?? []) as { business_id: string }[]).map((row) => row.business_id)
   );
 
-  const verifiedLookupDegraded = !!verifiedError;
+  const verifiedLookupDegraded = Boolean(verifiedLookupError);
 
   const data = {
     cities: citiesResult.data ?? emptySeedData.cities,

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -61,7 +61,7 @@ function getQueryCityId(query: string, cityOptions: { id: string; name: string }
 }
 
 export default function SearchPage() {
-  const {businesses, categories, cities} = useDirectoryData();
+  const {businesses, categories, cities, verifiedLookupDegraded} = useDirectoryData();
   const [searchParams] = useSearchParams();
   const rawQuery = searchParams.get('q') ?? '';
   const rawCityId = searchParams.get('city') ?? '';
@@ -118,6 +118,12 @@ export default function SearchPage() {
       />
       <Breadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Search' }]} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {verifiedLookupDegraded ? (
+          <div className="mb-6 border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 rounded-sm">
+            Verified business status is temporarily unavailable. Search results are still loaded, but verified badges may be missing.
+          </div>
+        ) : null}
+
         <div className="mb-12 border-b border-zinc-200 pb-6">
           <div className="inline-flex items-center gap-2 border border-zinc-200 bg-white text-zinc-600 px-3 py-1.5 font-mono text-[10px] tracking-[0.15em] mb-6 rounded-sm uppercase">
             <Search className="h-3 w-3 text-zinc-400" strokeWidth={1.5} /> Search Results


### PR DESCRIPTION
## Summary
- Add `verifiedLookupDegraded` boolean to `DirectoryDataState` type
- Set flag to `true` when `verified_businesses` table lookup fails
- Previously the verified lookup failure would silently fall back to an empty set with only a console warning

## Changes
- `src/directory-data.tsx`: Added `verifiedLookupDegraded` field to track verified lookup failures

## Context
Part of SAN-7: Surface verified-table failures and improve verified-state UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for verified business lookup performance issues, enabling the system to track when verification services experience degradation and expose this status throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->