### PR TITLE
fix(claim-status): remove CTA for complete_profile recommendation on pending claims

### DIFF
--- a/src/pages/ClaimStatusPage.tsx
+++ b/src/pages/ClaimStatusPage.tsx
@@ -109,7 +109,7 @@ function ClaimCard({ claim, business }: ClaimCardProps & { key?: string }) {
               <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Next opportunity</p>
               <h3 className="mt-3 text-xl font-bold tracking-tight text-zinc-950">{recommendation.title}</h3>
               <p className="mt-2 text-sm leading-6 text-zinc-600">{recommendation.description}</p>
-              {recommendation.href && recommendation.ctaLabel ? (
+              {recommendation.href && recommendation.ctaLabel && recommendation.type !== 'complete_profile' ? (
                 <Link
                   to={recommendation.href}
                   onClick={() => trackEvent('claim_status_recommendation_clicked', {


### PR DESCRIPTION
## Summary
- Fixed `/claim/status` page to not show a CTA button when the recommendation type is `complete_profile` and the claim is pending
- The recommendation card (title + description) is still visible, but the primary CTA link is now hidden for this case
- This aligns with the workflow where pending claimants cannot edit their profile until their claim is approved

## Changes
- Modified `src/pages/ClaimStatusPage.tsx` line 112 to add `&& recommendation.type !== 'complete_profile'` condition

## Testing
- `npm run lint` passes
- `npm run build` passes