### PR TITLE
fix(SAN-12): show complete_profile recommendation for pending claims

### DIFF
--- a/src/lib/recommendations.ts
+++ b/src/lib/recommendations.ts
@@ -58,6 +58,27 @@ export function getOwnerRecommendation({
   }
 
   if (claimStatus === 'pending') {
+    const progress = getOwnerProfileProgress(business);
+    const hasRequiredGaps = progress.requiredCompleted < progress.requiredTotal;
+
+    if (hasRequiredGaps) {
+      return {
+        type: 'complete_profile',
+        title: 'Complete Your Profile',
+        description: 'Your listing is still missing core details that help customers trust and contact your business.',
+      };
+    }
+
+    if (!business.contact?.website) {
+      return {
+        type: 'website_fix',
+        title: 'Add A Website',
+        description: 'Your core listing details are in place. A website gives customers one more reason to trust you before they call.',
+        href: '/websites-for-trades',
+        ctaLabel: 'Explore Websites',
+      };
+    }
+
     return {
       type: 'review_pending',
       title: 'Review In Progress',


### PR DESCRIPTION
## Summary

Fixed the recommendation logic for pending claims in `/claim/status` page. Previously, pending claims with incomplete profiles would always receive a `review_pending` recommendation, preventing them from seeing the `complete_profile` guidance.

Now, pending claims properly receive `complete_profile` recommendations when their profile is incomplete, allowing them to understand what needs to be completed while awaiting approval.

## Changes

- `src/lib/recommendations.ts`: Updated `getOwnerRecommendation()` to check profile completeness before returning `review_pending` for pending claims

## Test Plan

- [ ] Pending claim with incomplete profile should see `complete_profile` recommendation card
- [ ] Pending claim with complete profile but no website should see `website_fix` recommendation
- [ ] Pending claim with complete profile and website should see `review_pending`
- [ ] Approved claims continue to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recommendations for accounts with pending claims by evaluating profile completeness and website status to suggest more appropriate next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->