### PR TITLE
feat(SAN-14): deploy claim evidence schema and storage policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,9 +936,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,9 +948,6 @@
       "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -968,9 +962,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -983,9 +974,6 @@
       "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1000,9 +988,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1015,9 +1000,6 @@
       "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1032,9 +1014,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1026,6 @@
       "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1064,9 +1040,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1079,9 +1052,6 @@
       "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1096,9 +1066,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1112,9 +1079,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,9 +1091,6 @@
       "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1420,9 +1381,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,9 +1396,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1458,9 +1413,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1476,9 +1428,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3094,9 +3043,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3116,9 +3062,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -3140,9 +3083,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3162,9 +3102,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/pages/ClaimPage.tsx
+++ b/src/pages/ClaimPage.tsx
@@ -78,6 +78,8 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
     relationshipToBusiness: 'owner',
     message: '',
   });
+  const [evidenceFiles, setEvidenceFiles] = useState<File[]>([]);
+  const [uploadingEvidence, setUploadingEvidence] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [oauthLoading, setOauthLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -209,6 +211,42 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
     setSubmitting(true);
 
     try {
+      let evidenceUrls: string[] = [];
+
+      // Upload evidence files if any
+      if (evidenceFiles.length > 0 && user) {
+        setUploadingEvidence(true);
+        const uploadPromises = evidenceFiles.map(async (file) => {
+          const fileExt = file.name.split('.').pop();
+          const fileName = `${Date.now()}-${Math.random().toString(36).slice(2)}.${fileExt}`;
+          const filePath = `${user.id}/${fileName}`;
+
+          const { data, error: uploadError } = await supabase.storage
+            .from('claims')
+            .upload(filePath, file, {
+              cacheControl: '3600',
+              upsert: false,
+            });
+
+          if (uploadError) {
+            throw new Error(`Failed to upload ${file.name}: ${uploadError.message}`);
+          }
+
+          // Get public URL
+          const { data: urlData } = supabase.storage
+            .from('claims')
+            .getPublicUrl(filePath);
+
+          return urlData.publicUrl;
+        });
+
+        try {
+          evidenceUrls = await Promise.all(uploadPromises);
+        } finally {
+          setUploadingEvidence(false);
+        }
+      }
+
       const { data: claimId, error: submitError } = await supabase.rpc('submit_business_claim', {
         p_business_id: selectedBusiness.id,
         p_claimant_name: trimmedClaimantName,
@@ -216,6 +254,7 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
         p_claimant_phone: claimData.claimantPhone || null,
         p_relationship_to_business: claimData.relationshipToBusiness,
         p_message: claimData.message || null,
+        p_evidence_urls: evidenceUrls,
       });
 
       if (submitError) {
@@ -756,6 +795,31 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                       placeholder="Add anything that helps us verify ownership faster."
                     />
                   </div>
+                  <div className="mt-8">
+                    <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Evidence files (optional)</label>
+                    <p className="mt-1 text-sm text-zinc-500">Upload images or PDFs to support your claim (max 10MB per file).</p>
+                    <input
+                      type="file"
+                      multiple
+                      accept="image/jpeg,image/png,image/webp,application/pdf"
+                      onChange={(event) => {
+                        const files = event.target.files ? Array.from(event.target.files) : [];
+                        setEvidenceFiles(files);
+                      }}
+                      className="mt-3 w-full text-sm text-zinc-500 file:mr-4 file:border file:border-zinc-200 file:bg-zinc-50 file:px-4 file:py-2 file:text-xs file:font-bold file:uppercase file:tracking-wider file:text-zinc-700 file:transition-colors file:hover:border-zinc-900 file:hover:bg-zinc-100"
+                    />
+                    {evidenceFiles.length > 0 && (
+                      <ul className="mt-3 space-y-1">
+                        {evidenceFiles.map((file, index) => (
+                          <li key={index} className="flex items-center gap-2 text-sm text-zinc-600">
+                            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                            {file.name}
+                            <span className="text-zinc-400">({(file.size / 1024 / 1024).toFixed(2)} MB)</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                   <div className="mt-8 flex flex-col gap-4 border-t border-zinc-100 pt-6 sm:flex-row">
                     <button
                       type="button"
@@ -767,11 +831,11 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                     </button>
                     <button
                       type="submit"
-                      disabled={submitting}
+                      disabled={submitting || uploadingEvidence}
                       className="inline-flex flex-1 items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500 disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      {submitting ? 'Submitting claim...' : 'Submit claim for review'}
-                      {!submitting ? <ArrowRight className="h-4 w-4" strokeWidth={2.6} /> : null}
+                      {submitting || uploadingEvidence ? 'Uploading evidence...' : 'Submit claim for review'}
+                      {!submitting && !uploadingEvidence ? <ArrowRight className="h-4 w-4" strokeWidth={2.6} /> : null}
                     </button>
                   </div>
                 </section>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -117,6 +117,7 @@ create table if not exists public.business_claims (
   claimant_phone text,
   relationship_to_business text not null,
   message text,
+  evidence_urls text[] not null default '{}',
   reviewed_by uuid references public.profiles (id) on delete set null,
   reviewed_at timestamptz,
   rejection_reason text,
@@ -397,7 +398,8 @@ create or replace function public.submit_business_claim(
   p_claimant_email text,
   p_claimant_phone text default null,
   p_relationship_to_business text,
-  p_message text default null
+  p_message text default null,
+  p_evidence_urls text[] default '{}'
 )
 returns uuid
 language plpgsql
@@ -475,7 +477,8 @@ begin
       claimant_email,
       claimant_phone,
       relationship_to_business,
-      message
+      message,
+      evidence_urls
     )
     values (
       v_user_id,
@@ -484,7 +487,8 @@ begin
       v_claimant_email,
       p_claimant_phone,
       p_relationship_to_business,
-      p_message
+      p_message,
+      coalesce(p_evidence_urls, '{}')
     )
     returning id into v_claim_id;
   exception
@@ -516,7 +520,8 @@ grant execute on function public.submit_business_claim(
   text,
   text,
   text,
-  text
+  text,
+  text[]
 ) to authenticated;
 
 create or replace function public.delete_user_account()
@@ -758,3 +763,58 @@ on public.call_requests
 for select
 to authenticated
 using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
+
+-- Storage bucket for claim evidence uploads
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'claims',
+  'claims',
+  false,
+  10485760,
+  array['image/jpeg', 'image/png', 'image/webp', 'application/pdf']
+)
+on conflict (id) do update
+set
+  public = false,
+  file_size_limit = 10485760,
+  allowed_mime_types = array['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+
+-- Allow authenticated users to upload evidence to their own claims folder
+create policy "claims_upload_own"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'claims'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to read evidence from their own claims folder
+create policy "claims_read_own"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'claims'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to delete their own evidence
+create policy "claims_delete_own"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'claims'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow admins to read all claim evidence
+create policy "claims_read_admin"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'claims'
+  and exists (select 1 from public.profiles where id = auth.uid() and role = 'admin')
+);


### PR DESCRIPTION
## SAN-14: Deploy claim evidence schema and storage policy to production

### What this PR does

Adds production schema and storage changes for the claim evidence upload feature.

### Changes

**Database (supabase/schema.sql)**
- New column: `business_claims.evidence_urls text[] NOT NULL DEFAULT '{}'`
- Updated `submit_business_claim` RPC accepts `p_evidence_urls text[]` parameter

**Storage (supabase/schema.sql)**
- `claims` bucket: private, 10MB limit, jpeg/png/webp/pdf allowed
- RLS policies: users can upload/read/delete their own evidence; admins can read all

**Frontend (src/pages/ClaimPage.tsx)**
- Evidence file picker wired up
- Files upload to `claims/<user-id>/...` before form submission
- URLs passed to RPC as `p_evidence_urls`

### Deployment note

The SQL in `supabase/schema.sql` must be applied to the production Supabase database. Run via Supabase Dashboard SQL Editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now upload and attach evidence files (images and PDFs) when submitting business claims
* Selected evidence files are displayed with filenames and sizes before submission  
* Submit button is disabled during evidence upload to prevent duplicate submissions
* Claims can be submitted with or without evidence files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->