### PR TITLE
Fix claim state and owner access flow

### DIFF
--- a/.omx/tmux-hook.json
+++ b/.omx/tmux-hook.json
@@ -1,0 +1,19 @@
+{
+  "enabled": false,
+  "target": {
+    "type": "pane",
+    "value": "replace-with-tmux-pane-id"
+  },
+  "allowed_modes": [
+    "ralph",
+    "ultrawork",
+    "team"
+  ],
+  "cooldown_ms": 15000,
+  "max_injections_per_session": 200,
+  "prompt_template": "Continue from current mode state. [OMX_TMUX_INJECT]",
+  "marker": "[OMX_TMUX_INJECT]",
+  "dry_run": false,
+  "log_level": "info",
+  "skip_if_scrolling": true
+}

--- a/src/lib/claimState.ts
+++ b/src/lib/claimState.ts
@@ -1,0 +1,81 @@
+export type ClaimStatus = 'pending' | 'approved' | 'rejected' | 'revoked';
+
+export type ClaimState =
+  | 'claimable'
+  | 'pending_by_me'
+  | 'approved_by_me'
+  | 'claimed_by_other'
+  | 'verification_unknown';
+
+export interface UserBusinessClaim {
+  business_id: string;
+  status: ClaimStatus;
+}
+
+interface ClaimStateOptions {
+  businessId: string;
+  userClaims?: UserBusinessClaim[];
+  verifiedBusinessIds?: Set<string>;
+  verifiedLookupDegraded?: boolean;
+}
+
+export function getClaimStateForBusiness({
+  businessId,
+  userClaims = [],
+  verifiedBusinessIds = new Set<string>(),
+  verifiedLookupDegraded = false,
+}: ClaimStateOptions): ClaimState {
+  const hasApprovedClaim = userClaims.some((claim) =>
+    claim.business_id === businessId && claim.status === 'approved'
+  );
+  if (hasApprovedClaim) {
+    return 'approved_by_me';
+  }
+
+  const hasPendingClaim = userClaims.some((claim) =>
+    claim.business_id === businessId && claim.status === 'pending'
+  );
+  if (hasPendingClaim) {
+    return 'pending_by_me';
+  }
+
+  if (verifiedLookupDegraded) {
+    return 'verification_unknown';
+  }
+
+  if (verifiedBusinessIds.has(businessId)) {
+    return 'claimed_by_other';
+  }
+
+  return 'claimable';
+}
+
+export function getClaimStateCopy(state: ClaimState) {
+  switch (state) {
+    case 'pending_by_me':
+      return {
+        badge: 'Your claim is pending',
+        description: 'You already have a pending ownership request for this listing.',
+      };
+    case 'approved_by_me':
+      return {
+        badge: 'Already attached to you',
+        description: 'This listing is already attached to your account.',
+      };
+    case 'claimed_by_other':
+      return {
+        badge: 'Already claimed',
+        description: 'This listing already has an approved owner attached to it.',
+      };
+    case 'verification_unknown':
+      return {
+        badge: 'Status unavailable',
+        description: 'Ownership status could not be confirmed right now.',
+      };
+    case 'claimable':
+      return {
+        badge: 'Claim available',
+        description: 'No approved ownership block was found for this listing.',
+      };
+  }
+}

--- a/src/pages/BusinessPage.tsx
+++ b/src/pages/BusinessPage.tsx
@@ -21,6 +21,7 @@ import GalleryLightbox from '../components/GalleryLightbox';
 import Seo from '../components/Seo';
 import { useAuth } from '../contexts/AuthContext';
 import { allowSeedFallbackOnError } from '../directory-data';
+import { getClaimStateForBusiness, type ClaimState, type UserBusinessClaim } from '../lib/claimState';
 import { loadSeedDataFromJson } from '../lib/seedData';
 import { buildBreadcrumbJsonLd, toAbsoluteUrl } from '../lib/seo';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
@@ -190,6 +191,7 @@ export default function BusinessPage() {
   const [verificationLookupWarning, setVerificationLookupWarning] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [claimState, setClaimState] = useState<ClaimState>('claimable');
   const [isOwner, setIsOwner] = useState(false);
   const [ownerCheckError, setOwnerCheckError] = useState<string | null>(null);
   const [visibleMobileReviewCount, setVisibleMobileReviewCount] = useState(INITIAL_MOBILE_REVIEW_COUNT);
@@ -219,6 +221,7 @@ export default function BusinessPage() {
       setCategory(null);
       setVerificationState('unverified');
       setVerificationLookupWarning(null);
+      setClaimState('claimable');
       setIsOwner(false);
 
       if (!supabase || !isSupabaseConfigured()) {
@@ -418,9 +421,49 @@ export default function BusinessPage() {
   }, [businessId]);
 
   useEffect(() => {
+    if (!business || user) {
+      return;
+    }
+
+    if (verificationState === 'verified') {
+      setClaimState('claimed_by_other');
+      return;
+    }
+
+    if (verificationState === 'unknown') {
+      setClaimState('verification_unknown');
+      return;
+    }
+
+    setClaimState('claimable');
+  }, [business, user, verificationState]);
+
+  useEffect(() => {
     let isActive = true;
 
-    if (!business || !user || !supabase || !isSupabaseConfigured()) {
+    if (!business) {
+      setClaimState('claimable');
+      setIsOwner(false);
+      setOwnerCheckError(null);
+      return () => {
+        isActive = false;
+      };
+    }
+
+    if (!user) {
+      setIsOwner(false);
+      setOwnerCheckError(null);
+      return () => {
+        isActive = false;
+      };
+    }
+
+    if (!supabase || !isSupabaseConfigured()) {
+      if (verificationState === 'verified' || verificationState === 'unknown') {
+        setClaimState('verification_unknown');
+      } else {
+        setClaimState('claimable');
+      }
       setIsOwner(false);
       setOwnerCheckError(null);
       return () => {
@@ -432,23 +475,34 @@ export default function BusinessPage() {
       try {
         const { data, error } = await supabase
           .from('business_claims')
-          .select('id')
+          .select('business_id, status')
           .eq('business_id', business.id)
           .eq('user_id', user.id)
-          .eq('status', 'approved')
-          .maybeSingle();
+          .in('status', ['pending', 'approved']);
 
         if (error) {
           throw error;
         }
 
         if (isActive) {
-          setIsOwner(!!data);
+          const nextClaimState = getClaimStateForBusiness({
+            businessId: business.id,
+            userClaims: (data ?? []) as UserBusinessClaim[],
+            verifiedBusinessIds: verificationState === 'verified' ? new Set([business.id]) : new Set<string>(),
+            verifiedLookupDegraded: verificationState === 'unknown',
+          });
+          setClaimState(nextClaimState);
+          setIsOwner(nextClaimState === 'approved_by_me');
           setOwnerCheckError(null);
         }
       } catch (error: unknown) {
         console.error('[business-page] Failed to verify ownership.', error);
         if (isActive) {
+          if (verificationState === 'verified' || verificationState === 'unknown') {
+            setClaimState('verification_unknown');
+          } else {
+            setClaimState('claimable');
+          }
           setIsOwner(false);
           setOwnerCheckError('Could not verify owner access right now.');
         }
@@ -460,7 +514,7 @@ export default function BusinessPage() {
     return () => {
       isActive = false;
     };
-  }, [business, user]);
+  }, [business, user, verificationState]);
 
   useEffect(() => {
     if (!business) {
@@ -1015,7 +1069,7 @@ export default function BusinessPage() {
               </div>
             </section>
 
-            {verificationState === 'unverified' && (
+            {claimState === 'claimable' && verificationState === 'unverified' && (
               <div className="mt-8 p-8 border border-zinc-200 rounded-sm bg-zinc-50 shadow-sm">
                 <div className="bg-white p-6 rounded-xl border border-zinc-200 shadow-sm">
                   <AlertCircle className="w-5 h-5 text-zinc-500 mb-4" />
@@ -1038,7 +1092,29 @@ export default function BusinessPage() {
               </div>
             )}
 
-            {verificationState === 'unknown' && (
+            {claimState === 'pending_by_me' && (
+              <div className="mt-8 p-8 border border-amber-200 rounded-sm bg-amber-50 shadow-sm">
+                <div className="bg-white p-6 rounded-xl border border-amber-100 shadow-sm">
+                  <AlertCircle className="w-5 h-5 text-amber-500 mb-4" />
+                  <h4 className="font-black text-sm text-zinc-900 uppercase tracking-widest mb-2">Your claim is already in review</h4>
+                  <p className="text-sm text-zinc-600 mb-6 font-medium leading-relaxed">
+                    You already submitted an ownership request for this listing. The next step is checking the claim status page instead of starting a second claim.
+                  </p>
+                  <div className="space-y-3">
+                    <Link to="/claim/status" className="inline-flex items-center justify-between w-full bg-zinc-900 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-500 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>View claim status</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                    <Link to={paidLane.href} className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>{paidLane.cta}</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {claimState === 'verification_unknown' && (
               <div className="mt-8 p-8 border border-amber-200 rounded-sm bg-amber-50 shadow-sm">
                 <div className="bg-white p-6 rounded-xl border border-amber-100 shadow-sm">
                   <AlertCircle className="w-5 h-5 text-amber-500 mb-4" />
@@ -1047,17 +1123,10 @@ export default function BusinessPage() {
                     {verificationLookupWarning ?? 'We loaded the listing, but could not confirm whether verified ownership is available for this business right now.'}
                   </p>
                   <div className="space-y-3">
-                    {isOwner ? (
-                      <Link to="/owner/dashboard" className="inline-flex items-center justify-between w-full bg-orange-500 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-600 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                        <span>Owner Dashboard</span>
-                        <ArrowRight className="w-3 h-3" />
-                      </Link>
-                    ) : (
-                      <Link to={claimEntryPath} className="inline-flex items-center justify-between w-full bg-zinc-900 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-500 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                        <span>Claim Business</span>
-                        <ArrowRight className="w-3 h-3" />
-                      </Link>
-                    )}
+                    <Link to="/contact" className="inline-flex items-center justify-between w-full bg-zinc-900 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-500 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>Contact Support</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
                     <Link to={paidLane.href} className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
                       <span>{paidLane.cta}</span>
                       <ArrowRight className="w-3 h-3" />
@@ -1070,42 +1139,44 @@ export default function BusinessPage() {
               </div>
             )}
 
-            {verificationState === 'verified' && (
+            {claimState === 'approved_by_me' && (
               <div className="mt-8 p-8 border border-orange-200 rounded-sm bg-orange-50 shadow-sm">
                 <div className="bg-white p-6 rounded-xl border border-orange-100 shadow-sm">
                   <CheckCircle className="w-5 h-5 text-orange-500 mb-4" />
                   <h4 className="font-black text-sm text-zinc-900 uppercase tracking-widest mb-2">Verified Business</h4>
-                  {isOwner ? (
-                    <>
-                      <p className="text-sm text-zinc-600 mb-6 font-medium leading-relaxed">You are the verified owner of this business. Use the dashboard to manage the listing, or go straight into a paid lane if the bigger issue is leads, trust, or growth execution.</p>
-                      <div className="space-y-3">
-                        <Link to="/owner/dashboard" className="inline-flex items-center justify-between w-full bg-orange-500 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-600 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                          <span>Owner Dashboard</span>
-                          <ArrowRight className="w-3 h-3" />
-                        </Link>
-                        <Link to={paidLane.href} className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                          <span>{paidLane.cta}</span>
-                          <ArrowRight className="w-3 h-3" />
-                        </Link>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <p className="text-sm text-zinc-600 mb-6 font-medium leading-relaxed">
-                        This business has been verified as legitimately operated. If you need ownership help, contact support. If you are looking for direct website or growth help, you can go straight into a paid lane.
-                      </p>
-                      <div className="space-y-3">
-                        <Link to={paidLane.href} className="inline-flex items-center justify-between w-full bg-zinc-900 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-500 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                          <span>{paidLane.cta}</span>
-                          <ArrowRight className="w-3 h-3" />
-                        </Link>
-                        <Link to="/contact" className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
-                          <span>Contact Support</span>
-                          <ArrowRight className="w-3 h-3" />
-                        </Link>
-                      </div>
-                    </>
-                  )}
+                  <p className="text-sm text-zinc-600 mb-6 font-medium leading-relaxed">You are the verified owner of this business. Use the dashboard to manage the listing, or go straight into a paid lane if the bigger issue is leads, trust, or growth execution.</p>
+                  <div className="space-y-3">
+                    <Link to="/owner/dashboard" className="inline-flex items-center justify-between w-full bg-orange-500 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-600 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>Owner Dashboard</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                    <Link to={paidLane.href} className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>{paidLane.cta}</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {claimState === 'claimed_by_other' && (
+              <div className="mt-8 p-8 border border-orange-200 rounded-sm bg-orange-50 shadow-sm">
+                <div className="bg-white p-6 rounded-xl border border-orange-100 shadow-sm">
+                  <CheckCircle className="w-5 h-5 text-orange-500 mb-4" />
+                  <h4 className="font-black text-sm text-zinc-900 uppercase tracking-widest mb-2">Verified Business</h4>
+                  <p className="text-sm text-zinc-600 mb-6 font-medium leading-relaxed">
+                    This business already has an approved owner attached to it. If you need ownership help, contact support. If you are looking for direct website or growth help, you can go straight into a paid lane.
+                  </p>
+                  <div className="space-y-3">
+                    <Link to={paidLane.href} className="inline-flex items-center justify-between w-full bg-zinc-900 text-white rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:bg-orange-500 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>{paidLane.cta}</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                    <Link to="/contact" className="inline-flex items-center justify-between w-full border border-zinc-200 bg-white text-zinc-900 rounded-lg shadow-sm px-4 py-3 font-sans text-xs font-semibold tracking-wide hover:border-zinc-300 hover:bg-zinc-50 hover:-translate-y-0.5 hover:shadow-md transition-all">
+                      <span>Contact Support</span>
+                      <ArrowRight className="w-3 h-3" />
+                    </Link>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/pages/ClaimPage.tsx
+++ b/src/pages/ClaimPage.tsx
@@ -22,6 +22,7 @@ import Seo from '@/src/components/Seo';
 import type { Business } from '@/src/business';
 import { useAuth } from '@/src/contexts/AuthContext';
 import { useDirectoryData } from '@/src/directory-data';
+import { getClaimStateCopy, getClaimStateForBusiness, type ClaimState, type UserBusinessClaim } from '@/src/lib/claimState';
 import { getBusinessListingPath } from '@/src/lib/ownerProfile';
 import { isSupabaseConfigured, supabase } from '@/src/lib/supabase';
 import { trackEvent, trackPaidPlanIntentClicked, trackPaidPlanIntentViewed } from '@/src/lib/analytics';
@@ -71,6 +72,21 @@ const ALLOWED_CLAIM_EVIDENCE_TYPES = new Set([
   'image/webp',
 ]);
 
+function getClaimStateBadgeClasses(state: ClaimState) {
+  switch (state) {
+    case 'claimable':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-700';
+    case 'pending_by_me':
+      return 'border-amber-200 bg-amber-50 text-amber-700';
+    case 'approved_by_me':
+      return 'border-orange-200 bg-orange-50 text-orange-700';
+    case 'claimed_by_other':
+      return 'border-rose-200 bg-rose-50 text-rose-700';
+    case 'verification_unknown':
+      return 'border-zinc-200 bg-zinc-100 text-zinc-700';
+  }
+}
+
 export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
   const navigate = useNavigate();
   const { user, loading: authLoading, signInWithGoogle } = useAuth();
@@ -78,6 +94,8 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
     businesses,
     categories,
     cities,
+    verifiedBusinessIds,
+    verifiedLookupDegraded,
     isLoading: directoryLoading,
     error: directoryError,
   } = useDirectoryData();
@@ -95,6 +113,9 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
   const [evidenceFiles, setEvidenceFiles] = useState<File[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [oauthLoading, setOauthLoading] = useState(false);
+  const [claimsLoading, setClaimsLoading] = useState(false);
+  const [claimsDegraded, setClaimsDegraded] = useState(false);
+  const [userClaims, setUserClaims] = useState<UserBusinessClaim[]>([]);
   const [error, setError] = useState<string | null>(null);
   const trackedClaimStarts = useRef(new Set<string>());
   const claimsAvailable = Boolean(supabase && isSupabaseConfigured());
@@ -119,6 +140,50 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
   );
   const targetedBusinessCityName = targetedBusiness ? cityNames.get(targetedBusiness.cityId) : undefined;
   const targetedBusinessCategoryName = targetedBusiness ? categoryNames.get(targetedBusiness.categoryId) : undefined;
+  const claimStateLookupDegraded = verifiedLookupDegraded || claimsDegraded;
+  const targetedClaimState = targetedBusiness
+    ? getClaimStateForBusiness({
+        businessId: targetedBusiness.id,
+        userClaims,
+        verifiedBusinessIds,
+        verifiedLookupDegraded: claimStateLookupDegraded,
+      })
+    : 'claimable';
+  const targetedClaimStateCopy = getClaimStateCopy(targetedClaimState);
+
+  useEffect(() => {
+    async function fetchUserClaims() {
+      if (!user || !supabase || !claimsAvailable) {
+        setUserClaims([]);
+        setClaimsLoading(false);
+        setClaimsDegraded(false);
+        return;
+      }
+
+      setClaimsLoading(true);
+      setClaimsDegraded(false);
+
+      try {
+        const { data, error: fetchError } = await supabase
+          .from('business_claims')
+          .select('business_id, status')
+          .eq('user_id', user.id);
+
+        if (fetchError) {
+          throw fetchError;
+        }
+
+        setUserClaims((data ?? []) as UserBusinessClaim[]);
+      } catch (claimError) {
+        console.error('Failed to load user claim states:', claimError);
+        setClaimsDegraded(true);
+      } finally {
+        setClaimsLoading(false);
+      }
+    }
+
+    void fetchUserClaims();
+  }, [claimsAvailable, user]);
 
   useEffect(() => {
     if (!user || directoryLoading || !selectedBusinessId) {
@@ -168,6 +233,17 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
       })
       .slice(0, 10);
   }, [businesses, categoryNames, cityNames, searchQuery]);
+  const filteredBusinessResults = useMemo(() => (
+    filteredBusinesses.map((business) => ({
+      business,
+      claimState: getClaimStateForBusiness({
+        businessId: business.id,
+        userClaims,
+        verifiedBusinessIds,
+        verifiedLookupDegraded: claimStateLookupDegraded,
+      }),
+    }))
+  ), [filteredBusinesses, userClaims, verifiedBusinessIds, claimStateLookupDegraded]);
 
   const listingPath = getBusinessListingPath(selectedBusiness);
   const selectedCityName = selectedBusiness ? cityNames.get(selectedBusiness.cityId) : undefined;
@@ -244,6 +320,26 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
     if (!user || !selectedBusiness || !supabase || !claimsAvailable) {
+      return;
+    }
+
+    if (targetedClaimState === 'pending_by_me') {
+      navigate('/claim/status');
+      return;
+    }
+
+    if (targetedClaimState === 'approved_by_me') {
+      navigate('/owner/dashboard');
+      return;
+    }
+
+    if (targetedClaimState === 'claimed_by_other') {
+      setError('This listing has already been claimed by another owner. Contact support if you believe that is incorrect.');
+      return;
+    }
+
+    if (targetedClaimState === 'verification_unknown') {
+      setError('We cannot confirm ownership status for this listing right now. Please try again later or contact support.');
       return;
     }
 
@@ -360,7 +456,7 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
           || msg.includes('same time')
           || msg.includes('already been claimed')
         ) {
-          setError('Another claim for this listing is already in review. Please check the status page.');
+          setError('This listing has already been claimed by another owner. Contact support if you believe that is incorrect.');
           return;
         }
 
@@ -413,7 +509,12 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
     }
   }
 
-  if (authLoading || (user && directoryLoading) || (!user && Boolean(selectedBusinessId) && directoryLoading)) {
+  if (
+    authLoading
+    || (user && directoryLoading)
+    || (!user && Boolean(selectedBusinessId) && directoryLoading)
+    || (user && claimsLoading)
+  ) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-zinc-50">
         <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900" />
@@ -671,6 +772,12 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
             </div>
           ) : null}
 
+          {claimsDegraded ? (
+            <div className="mb-8 border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-800">
+              We could not confirm your current claim states right now. Claim actions are temporarily blocked until that lookup succeeds.
+            </div>
+          ) : null}
+
           {step === 1 ? (
             <div className="grid gap-8 lg:grid-cols-[minmax(0,1.35fr)_22rem]">
               <section className="border-2 border-zinc-900 bg-white">
@@ -704,14 +811,14 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                   </div>
                   <p className="mt-3 text-sm text-zinc-500">
                     {searchQuery.trim()
-                      ? `${filteredBusinesses.length} matching ${filteredBusinesses.length === 1 ? 'listing' : 'listings'}`
+                      ? `${filteredBusinessResults.length} matching ${filteredBusinessResults.length === 1 ? 'listing' : 'listings'}`
                       : 'Start typing to see matching listings.'}
                   </p>
                 </div>
                 <div className="px-6 py-6 sm:px-8">
-                  {filteredBusinesses.length > 0 ? (
+                  {filteredBusinessResults.length > 0 ? (
                     <div className="space-y-3">
-                      {filteredBusinesses.map((business) => (
+                      {filteredBusinessResults.map(({ business, claimState }) => (
                         <button
                           key={business.id}
                           type="button"
@@ -727,6 +834,11 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                               </span>
                               <span className="h-1 w-1 rounded-full bg-zinc-300" />
                               <span>{categoryNames.get(business.categoryId) ?? business.categoryId}</span>
+                            </div>
+                            <div className="mt-3">
+                              <span className={`inline-flex items-center border px-2.5 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.16em] ${getClaimStateBadgeClasses(claimState)}`}>
+                                {getClaimStateCopy(claimState).badge}
+                              </span>
                             </div>
                             {business.contact.address ? (
                               <p className="mt-2 text-sm text-zinc-500">{business.contact.address}</p>
@@ -817,7 +929,7 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
             </div>
           ) : (
             <div className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_24rem]">
-              <form onSubmit={handleSubmit} className="space-y-8">
+              <div className="space-y-8">
                 <section className="border-2 border-zinc-900 bg-white">
                   <div className="border-b-2 border-zinc-900 bg-zinc-900 px-6 py-6 text-white sm:px-8">
                     <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-orange-300">Selected listing</p>
@@ -829,10 +941,15 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                   </div>
                   <div className="grid gap-6 px-6 py-6 sm:px-8 lg:grid-cols-[minmax(0,1fr)_15rem]">
                     <div>
+                      <div>
+                        <span className={`inline-flex items-center border px-2.5 py-1 font-mono text-[10px] font-bold uppercase tracking-[0.16em] ${getClaimStateBadgeClasses(targetedClaimState)}`}>
+                          {targetedClaimStateCopy.badge}
+                        </span>
+                      </div>
                       {selectedBusiness?.contact.address ? (
-                        <p className="text-sm leading-6 text-zinc-600">{selectedBusiness.contact.address}</p>
+                        <p className="mt-4 text-sm leading-6 text-zinc-600">{selectedBusiness.contact.address}</p>
                       ) : (
-                        <p className="text-sm leading-6 text-zinc-500">No street address is published for this listing yet.</p>
+                        <p className="mt-4 text-sm leading-6 text-zinc-500">No street address is published for this listing yet.</p>
                       )}
                     </div>
                     {listingPath ? (
@@ -847,130 +964,177 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
                   </div>
                 </section>
 
-                <section className="border border-zinc-200 bg-white p-6 sm:p-8">
-                  <div className="grid gap-6 md:grid-cols-2">
-                    <div>
-                      <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-                        <User className="h-3.5 w-3.5" />
-                        Full name
-                      </label>
-                      <input
-                        type="text"
-                        value={claimData.claimantName}
-                        onChange={(event) => setClaimData({ ...claimData, claimantName: event.target.value })}
-                        required
-                        className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
-                        placeholder="Your name"
-                      />
-                    </div>
-                    <div>
-                      <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-                        <Phone className="h-3.5 w-3.5" />
-                        Phone number
-                      </label>
-                      <input
-                        type="tel"
-                        value={claimData.claimantPhone}
-                        onChange={(event) => setClaimData({ ...claimData, claimantPhone: event.target.value })}
-                        className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
-                        placeholder="(250) 555-0000"
-                      />
-                    </div>
-                    <div>
-                      <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-                        <ShieldCheck className="h-3.5 w-3.5" />
-                        Your role
-                      </label>
-                      <select
-                        value={claimData.relationshipToBusiness}
-                        onChange={(event) => setClaimData({ ...claimData, relationshipToBusiness: event.target.value })}
-                        className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
-                      >
-                        <option value="owner">Owner</option>
-                        <option value="manager">Manager</option>
-                        <option value="employee">Employee</option>
-                        <option value="authorized">Authorized representative</option>
-                      </select>
-                    </div>
-                  </div>
-                  <p className="mt-6 text-sm leading-6 text-zinc-600">
-                    Claim notifications are sent to your signed-in account email:
-                    {' '}
-                    <span className="font-medium text-zinc-900">{accountEmail ?? 'No account email available'}</span>
-                  </p>
-                  <div className="mt-8">
-                    <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Verification notes</label>
-                    <textarea
-                      value={claimData.message}
-                      onChange={(event) => setClaimData({ ...claimData, message: event.target.value })}
-                      rows={5}
-                      className="mt-3 w-full resize-none border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
-                      placeholder="Add anything that helps us verify ownership faster."
-                    />
-                  </div>
-                  <div className="mt-8">
-                    <div className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
-                      <Paperclip className="h-3.5 w-3.5" />
-                      Evidence upload
-                    </div>
-                    <p className="mt-3 text-sm leading-6 text-zinc-600">
-                      Upload optional proof like a business license, utility bill, storefront photo, or signed authorization letter.
-                    </p>
-                    <label className="mt-4 inline-flex cursor-pointer items-center gap-2 border border-zinc-200 bg-zinc-50 px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-700 transition-colors hover:border-zinc-900 hover:bg-white hover:text-zinc-950">
-                      <FileText className="h-4 w-4" strokeWidth={2.2} />
-                      Add evidence files
-                      <input
-                        type="file"
-                        accept=".pdf,image/jpeg,image/png,image/webp"
-                        multiple
-                        onChange={handleEvidenceSelection}
-                        className="sr-only"
-                      />
-                    </label>
-                    <p className="mt-3 text-xs leading-5 text-zinc-500">
-                      Up to {MAX_CLAIM_EVIDENCE_FILES} files. PDF, JPG, PNG, or WEBP. Maximum 10 MB each.
-                    </p>
-                    {evidenceFiles.length > 0 ? (
-                      <div className="mt-4 space-y-2">
-                        {evidenceFiles.map((file, index) => (
-                          <div key={`${file.name}-${file.size}-${index}`} className="flex items-center justify-between gap-3 border border-zinc-200 bg-zinc-50 px-3 py-3 text-sm text-zinc-700">
-                            <div className="min-w-0">
-                              <p className="truncate font-medium text-zinc-900">{file.name}</p>
-                              <p className="text-xs text-zinc-500">{(file.size / (1024 * 1024)).toFixed(1)} MB</p>
-                            </div>
-                            <button
-                              type="button"
-                              onClick={() => handleRemoveEvidenceFile(index)}
-                              className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 transition-colors hover:text-rose-600"
-                            >
-                              <X className="h-3.5 w-3.5" strokeWidth={2.2} />
-                              Remove
-                            </button>
-                          </div>
-                        ))}
+                {targetedClaimState === 'claimable' ? (
+                  <form onSubmit={handleSubmit} className="space-y-8">
+                    <section className="border border-zinc-200 bg-white p-6 sm:p-8">
+                      <div className="grid gap-6 md:grid-cols-2">
+                        <div>
+                          <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
+                            <User className="h-3.5 w-3.5" />
+                            Full name
+                          </label>
+                          <input
+                            type="text"
+                            value={claimData.claimantName}
+                            onChange={(event) => setClaimData({ ...claimData, claimantName: event.target.value })}
+                            required
+                            className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
+                            placeholder="Your name"
+                          />
+                        </div>
+                        <div>
+                          <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
+                            <Phone className="h-3.5 w-3.5" />
+                            Phone number
+                          </label>
+                          <input
+                            type="tel"
+                            value={claimData.claimantPhone}
+                            onChange={(event) => setClaimData({ ...claimData, claimantPhone: event.target.value })}
+                            className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
+                            placeholder="(250) 555-0000"
+                          />
+                        </div>
+                        <div>
+                          <label className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                            Your role
+                          </label>
+                          <select
+                            value={claimData.relationshipToBusiness}
+                            onChange={(event) => setClaimData({ ...claimData, relationshipToBusiness: event.target.value })}
+                            className="mt-3 w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
+                          >
+                            <option value="owner">Owner</option>
+                            <option value="manager">Manager</option>
+                            <option value="employee">Employee</option>
+                            <option value="authorized">Authorized representative</option>
+                          </select>
+                        </div>
                       </div>
-                    ) : null}
-                  </div>
-                  <div className="mt-8 flex flex-col gap-4 border-t border-zinc-100 pt-6 sm:flex-row">
-                    <button
-                      type="button"
-                      onClick={handleBackToSearch}
-                      className="inline-flex items-center justify-center gap-2 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
-                    >
-                      <ArrowLeft className="h-4 w-4" strokeWidth={2.4} />
-                      Change listing
-                    </button>
-                    <button
-                      type="submit"
-                      disabled={submitting}
-                      className="inline-flex flex-1 items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500 disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {submitting ? 'Submitting claim...' : 'Submit claim for review'}
-                      {!submitting ? <ArrowRight className="h-4 w-4" strokeWidth={2.6} /> : null}
-                    </button>
-                  </div>
-                </section>
-              </form>
+                      <p className="mt-6 text-sm leading-6 text-zinc-600">
+                        Claim notifications are sent to your signed-in account email:
+                        {' '}
+                        <span className="font-medium text-zinc-900">{accountEmail ?? 'No account email available'}</span>
+                      </p>
+                      <div className="mt-8">
+                        <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Verification notes</label>
+                        <textarea
+                          value={claimData.message}
+                          onChange={(event) => setClaimData({ ...claimData, message: event.target.value })}
+                          rows={5}
+                          className="mt-3 w-full resize-none border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
+                          placeholder="Add anything that helps us verify ownership faster."
+                        />
+                      </div>
+                      <div className="mt-8">
+                        <div className="flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">
+                          <Paperclip className="h-3.5 w-3.5" />
+                          Evidence upload
+                        </div>
+                        <p className="mt-3 text-sm leading-6 text-zinc-600">
+                          Upload optional proof like a business license, utility bill, storefront photo, or signed authorization letter.
+                        </p>
+                        <label className="mt-4 inline-flex cursor-pointer items-center gap-2 border border-zinc-200 bg-zinc-50 px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-700 transition-colors hover:border-zinc-900 hover:bg-white hover:text-zinc-950">
+                          <FileText className="h-4 w-4" strokeWidth={2.2} />
+                          Add evidence files
+                          <input
+                            type="file"
+                            accept=".pdf,image/jpeg,image/png,image/webp"
+                            multiple
+                            onChange={handleEvidenceSelection}
+                            className="sr-only"
+                          />
+                        </label>
+                        <p className="mt-3 text-xs leading-5 text-zinc-500">
+                          Up to {MAX_CLAIM_EVIDENCE_FILES} files. PDF, JPG, PNG, or WEBP. Maximum 10 MB each.
+                        </p>
+                        {evidenceFiles.length > 0 ? (
+                          <div className="mt-4 space-y-2">
+                            {evidenceFiles.map((file, index) => (
+                              <div key={`${file.name}-${file.size}-${index}`} className="flex items-center justify-between gap-3 border border-zinc-200 bg-zinc-50 px-3 py-3 text-sm text-zinc-700">
+                                <div className="min-w-0">
+                                  <p className="truncate font-medium text-zinc-900">{file.name}</p>
+                                  <p className="text-xs text-zinc-500">{(file.size / (1024 * 1024)).toFixed(1)} MB</p>
+                                </div>
+                                <button
+                                  type="button"
+                                  onClick={() => handleRemoveEvidenceFile(index)}
+                                  className="inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 transition-colors hover:text-rose-600"
+                                >
+                                  <X className="h-3.5 w-3.5" strokeWidth={2.2} />
+                                  Remove
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                      <div className="mt-8 flex flex-col gap-4 border-t border-zinc-100 pt-6 sm:flex-row">
+                        <button
+                          type="button"
+                          onClick={handleBackToSearch}
+                          className="inline-flex items-center justify-center gap-2 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
+                        >
+                          <ArrowLeft className="h-4 w-4" strokeWidth={2.4} />
+                          Change listing
+                        </button>
+                        <button
+                          type="submit"
+                          disabled={submitting}
+                          className="inline-flex flex-1 items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {submitting ? 'Submitting claim...' : 'Submit claim for review'}
+                          {!submitting ? <ArrowRight className="h-4 w-4" strokeWidth={2.6} /> : null}
+                        </button>
+                      </div>
+                    </section>
+                  </form>
+                ) : (
+                  <section className="border border-zinc-200 bg-white p-6 sm:p-8">
+                    <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Next step</p>
+                    <h3 className="mt-4 text-3xl font-bold tracking-tight text-zinc-950">{targetedClaimStateCopy.badge}</h3>
+                    <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-600">{targetedClaimStateCopy.description}</p>
+                    <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+                      {targetedClaimState === 'pending_by_me' ? (
+                        <Link
+                          to="/claim/status"
+                          className="inline-flex items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500"
+                        >
+                          View claim status
+                          <ArrowRight className="h-4 w-4" strokeWidth={2.6} />
+                        </Link>
+                      ) : null}
+                      {targetedClaimState === 'approved_by_me' ? (
+                        <Link
+                          to="/owner/dashboard"
+                          className="inline-flex items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500"
+                        >
+                          Open owner dashboard
+                          <ArrowRight className="h-4 w-4" strokeWidth={2.6} />
+                        </Link>
+                      ) : null}
+                      {targetedClaimState === 'claimed_by_other' || targetedClaimState === 'verification_unknown' ? (
+                        <Link
+                          to="/contact"
+                          className="inline-flex items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500"
+                        >
+                          Contact support
+                          <ArrowRight className="h-4 w-4" strokeWidth={2.6} />
+                        </Link>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={handleBackToSearch}
+                        className="inline-flex items-center justify-center gap-2 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
+                      >
+                        <ArrowLeft className="h-4 w-4" strokeWidth={2.4} />
+                        Change listing
+                      </button>
+                    </div>
+                  </section>
+                )}
+              </div>
 
               <aside className="space-y-5">
                 <section className="border border-zinc-200 bg-white p-5">

--- a/src/pages/OwnerDashboardPage.tsx
+++ b/src/pages/OwnerDashboardPage.tsx
@@ -97,6 +97,10 @@ function resolveOverrideValue(overrideValue: string | null | undefined, fallback
   return overrideValue ?? '';
 }
 
+function resolveClaimLabel(claim: BusinessClaim, businesses: Business[]) {
+  return businesses.find((entry) => entry.id === claim.business_id)?.name ?? claim.business_id;
+}
+
 export default function OwnerDashboardPage() {
   const { user, loading: authLoading } = useAuth();
   const { businesses, cities, isLoading: directoryLoading, refresh } = useDirectoryData();
@@ -166,6 +170,15 @@ export default function OwnerDashboardPage() {
     }
   }
 
+  async function handleClaimSelection(claim: BusinessClaim) {
+    setLoading(true);
+    try {
+      await hydrateClaim(claim);
+    } finally {
+      setLoading(false);
+    }
+  }
+
   useEffect(() => {
     async function fetchClaims() {
       if (directoryLoading) {
@@ -195,8 +208,13 @@ export default function OwnerDashboardPage() {
           const preferredClaim = preferredClaimId
             ? claimList.find((claim) => claim.id === preferredClaimId) ?? null
             : null;
+          const initialClaim = preferredClaim ?? claimList[0];
+          const initialClaimHasBusiness = businesses.some((entry) => entry.id === initialClaim.business_id);
+          const recoverableClaim = claimList.find((claim) =>
+            businesses.some((entry) => entry.id === claim.business_id)
+          ) ?? null;
 
-          await hydrateClaim(preferredClaim ?? claimList[0]);
+          await hydrateClaim(initialClaimHasBusiness ? initialClaim : (recoverableClaim ?? initialClaim));
         }
       } catch (caughtError) {
         setError(caughtError instanceof Error ? caughtError.message : 'Failed to load the owner dashboard.');
@@ -346,7 +364,7 @@ export default function OwnerDashboardPage() {
     );
   }
 
-  if (!approvedClaim || !business) {
+  if (!approvedClaim) {
     return (
       <div className="min-h-screen bg-[#FAFAFA] px-4 py-24">
         {pageSeo}
@@ -373,6 +391,63 @@ export default function OwnerDashboardPage() {
               className="inline-flex items-center justify-center border border-zinc-200 bg-white px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
             >
               View claim status
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!business) {
+    return (
+      <div className="min-h-screen bg-[#FAFAFA] px-4 py-24">
+        {pageSeo}
+        <div className="mx-auto max-w-3xl border-2 border-zinc-900 bg-white p-8 shadow-[8px_8px_0px_0px_rgba(24,24,27,1)] sm:p-10">
+          <SectionEyebrow
+            icon={ShieldCheck}
+            className="inline-flex items-center gap-2 bg-zinc-900 px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-white"
+            iconClassName="h-3.5 w-3.5 text-orange-400"
+          >
+            Owner Dashboard
+          </SectionEyebrow>
+          <h1 className="mt-6 text-4xl font-bold uppercase tracking-tight text-zinc-950">Owner access is active, but the listing could not be loaded.</h1>
+          <p className="mt-4 max-w-2xl text-lg leading-8 text-zinc-600">
+            Your approved claim still exists, but the linked business record is unavailable in the current directory data. Check claim status or contact support before trying again.
+          </p>
+          {approvedClaims.length > 1 ? (
+            <div className="mt-8 border-t border-zinc-200 pt-6">
+              <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Try another approved listing</label>
+              <select
+                value={selectedClaimId}
+                onChange={async (event) => {
+                  const nextClaim = approvedClaims.find((claim) => claim.id === event.target.value);
+                  if (nextClaim) {
+                    await handleClaimSelection(nextClaim);
+                  }
+                }}
+                className="mt-3 w-full border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none focus:border-zinc-900"
+              >
+                {approvedClaims.map((claim) => (
+                  <option key={claim.id} value={claim.id}>
+                    {resolveClaimLabel(claim, businesses)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <Link
+              to="/claim/status"
+              className="inline-flex items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-all hover:border-orange-500 hover:bg-orange-500"
+            >
+              View claim status
+              <ArrowRight className="h-4 w-4" strokeWidth={2.6} />
+            </Link>
+            <Link
+              to="/contact"
+              className="inline-flex items-center justify-center border border-zinc-200 bg-white px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:bg-zinc-50 hover:text-zinc-950"
+            >
+              Contact support
             </Link>
           </div>
         </div>
@@ -430,24 +505,16 @@ export default function OwnerDashboardPage() {
                     onChange={async (event) => {
                       const nextClaim = approvedClaims.find((claim) => claim.id === event.target.value);
                       if (nextClaim) {
-                        setLoading(true);
-                        try {
-                          await hydrateClaim(nextClaim);
-                        } finally {
-                          setLoading(false);
-                        }
+                        await handleClaimSelection(nextClaim);
                       }
                     }}
                     className="mt-3 w-full border border-zinc-200 bg-white px-4 py-3 text-sm text-zinc-900 outline-none focus:border-zinc-900"
                   >
-                    {approvedClaims.map((claim) => {
-                      const optionBusiness = businesses.find((entry) => entry.id === claim.business_id);
-                      return (
-                        <option key={claim.id} value={claim.id}>
-                          {optionBusiness?.name ?? claim.business_id}
-                        </option>
-                      );
-                    })}
+                    {approvedClaims.map((claim) => (
+                      <option key={claim.id} value={claim.id}>
+                        {resolveClaimLabel(claim, businesses)}
+                      </option>
+                    ))}
                   </select>
                 </div>
               ) : null}


### PR DESCRIPTION
## Summary
- add a shared claim-state helper for claimable, pending-by-me, approved-by-me, claimed-by-other, and verification-unknown states
- use that state on claim entry and public business pages so users see the correct next step before submitting
- fix the owner dashboard empty state so approved owner access is not mislabeled as having no approved claims

## Verification
- npm install
- npm run lint
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claim-state UI across listing, claim, and owner pages: shows claimable, pending, approved, claimed-by-other, and verification-unknown states.
  * Per-listing claim badges and contextual right-hand panels that guide next steps or show the claim form when appropriate.

* **Improvements**
  * Claim submission now routes users to the correct flow or message based on verification/ownership state and degraded-lookup handling.
  * Owner dashboard: clearer claim selection, labels, and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->