### PR TITLE
Add Life OS eval loop with capability ranking and persistent artifacts

### DIFF
--- a/artifacts/life-os/eval-report-2026-04-15T21-52-53.433Z.json
+++ b/artifacts/life-os/eval-report-2026-04-15T21-52-53.433Z.json
@@ -1,0 +1,213 @@
+{
+  "generatedAt": "2026-04-15T21:52:53.433Z",
+  "fixtureCount": 5,
+  "metrics": {
+    "loopClosureRate": 0.5957,
+    "unnecessaryQuestionRate": 0.2198,
+    "approvalCorrectnessRate": 0.7037,
+    "memoryUsefulnessRate": 0.7,
+    "interventionUsefulnessRate": 0.6,
+    "blockerRecurrenceRate": 0.7
+  },
+  "topRecurringBlockers": [
+    {
+      "blockerId": "inbox-overload",
+      "blockerLabel": "Inbox overload hides high-value leads",
+      "count": 2,
+      "recurringCount": 2
+    },
+    {
+      "blockerId": "proposal-fragmentation",
+      "blockerLabel": "Proposal artifacts are scattered across tools",
+      "count": 2,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "calendar-friction",
+      "blockerLabel": "Calendar friction for workout scheduling",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "context-loss",
+      "blockerLabel": "Loses relationship context between sessions",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "dependency-uncertainty",
+      "blockerLabel": "Unclear owner for pending dependencies",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "constraint-conflict",
+      "blockerLabel": "Conflicting constraints are not surfaced early",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "sleep-plan-drift",
+      "blockerLabel": "Bedtime plan drifts after evening meetings",
+      "count": 1,
+      "recurringCount": 0
+    },
+    {
+      "blockerId": "timing-mismatch",
+      "blockerLabel": "Outreach timing mismatches recipient preferences",
+      "count": 1,
+      "recurringCount": 0
+    }
+  ],
+  "capabilityProposals": [
+    {
+      "capabilityGap": "constraint_resolution",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.91,
+      "impactedScenarios": [
+        "contradictory_requests"
+      ],
+      "recommendationScore": 0.7995
+    },
+    {
+      "capabilityGap": "email_prioritization",
+      "evidenceCount": 2,
+      "recurringEvidenceCount": 2,
+      "averageSeverity": 0.805,
+      "impactedScenarios": [
+        "work_income",
+        "stalled_loops"
+      ],
+      "recommendationScore": 0.7923
+    },
+    {
+      "capabilityGap": "dependency_mapping",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.89,
+      "impactedScenarios": [
+        "stalled_loops"
+      ],
+      "recommendationScore": 0.7905
+    },
+    {
+      "capabilityGap": "calendar_orchestration",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.8,
+      "impactedScenarios": [
+        "health_performance"
+      ],
+      "recommendationScore": 0.75
+    },
+    {
+      "capabilityGap": "relationship_memory_synthesis",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.78,
+      "impactedScenarios": [
+        "relationships_networking"
+      ],
+      "recommendationScore": 0.741
+    },
+    {
+      "capabilityGap": "artifact_consolidation",
+      "evidenceCount": 2,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.71,
+      "impactedScenarios": [
+        "work_income",
+        "contradictory_requests"
+      ],
+      "recommendationScore": 0.5745
+    },
+    {
+      "capabilityGap": "timing_personalization",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 0,
+      "averageSeverity": 0.64,
+      "impactedScenarios": [
+        "relationships_networking"
+      ],
+      "recommendationScore": 0.328
+    },
+    {
+      "capabilityGap": "circadian_routine_adjustment",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 0,
+      "averageSeverity": 0.62,
+      "impactedScenarios": [
+        "health_performance"
+      ],
+      "recommendationScore": 0.319
+    }
+  ],
+  "skillHealth": [
+    {
+      "skillId": "pipeline-prioritization",
+      "successRate": 0.8571,
+      "totalAttempts": 7,
+      "trend": "promote"
+    },
+    {
+      "skillId": "habit-planning",
+      "successRate": 0.8333,
+      "totalAttempts": 6,
+      "trend": "promote"
+    },
+    {
+      "skillId": "follow-up-cadence",
+      "successRate": 0.8,
+      "totalAttempts": 5,
+      "trend": "promote"
+    },
+    {
+      "skillId": "conversation-briefing",
+      "successRate": 0.75,
+      "totalAttempts": 4,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "campaign-reset",
+      "successRate": 0.6,
+      "totalAttempts": 5,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "approval-routing",
+      "successRate": 0.6,
+      "totalAttempts": 5,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "nutrition-basics",
+      "successRate": 0.5,
+      "totalAttempts": 4,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "meeting-prep",
+      "successRate": 0.4,
+      "totalAttempts": 5,
+      "trend": "decay"
+    },
+    {
+      "skillId": "dependency-resolution",
+      "successRate": 0.3333,
+      "totalAttempts": 6,
+      "trend": "decay"
+    },
+    {
+      "skillId": "constraint-clarification",
+      "successRate": 0.3333,
+      "totalAttempts": 6,
+      "trend": "decay"
+    }
+  ],
+  "summary": {
+    "mostRecurringBlocker": "inbox-overload",
+    "topCapabilityUpgrade": "constraint_resolution",
+    "campaignLoopTrend": "flat_or_declining"
+  }
+}

--- a/artifacts/life-os/improvement-artifacts-2026-04-15T21-52-53.433Z.json
+++ b/artifacts/life-os/improvement-artifacts-2026-04-15T21-52-53.433Z.json
@@ -1,0 +1,20 @@
+{
+  "generatedAt": "2026-04-15T21:52:53.433Z",
+  "topRecurringBlockers": [
+    "inbox-overload",
+    "proposal-fragmentation",
+    "calendar-friction"
+  ],
+  "capabilityUpgradeRecommendation": "constraint_resolution",
+  "promotedSkills": [
+    "pipeline-prioritization",
+    "habit-planning",
+    "follow-up-cadence"
+  ],
+  "decayedSkills": [
+    "meeting-prep",
+    "dependency-resolution",
+    "constraint-clarification"
+  ],
+  "campaignLoopTrend": "flat_or_declining"
+}

--- a/artifacts/life-os/latest-eval-report.json
+++ b/artifacts/life-os/latest-eval-report.json
@@ -1,0 +1,213 @@
+{
+  "generatedAt": "2026-04-15T21:52:53.433Z",
+  "fixtureCount": 5,
+  "metrics": {
+    "loopClosureRate": 0.5957,
+    "unnecessaryQuestionRate": 0.2198,
+    "approvalCorrectnessRate": 0.7037,
+    "memoryUsefulnessRate": 0.7,
+    "interventionUsefulnessRate": 0.6,
+    "blockerRecurrenceRate": 0.7
+  },
+  "topRecurringBlockers": [
+    {
+      "blockerId": "inbox-overload",
+      "blockerLabel": "Inbox overload hides high-value leads",
+      "count": 2,
+      "recurringCount": 2
+    },
+    {
+      "blockerId": "proposal-fragmentation",
+      "blockerLabel": "Proposal artifacts are scattered across tools",
+      "count": 2,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "calendar-friction",
+      "blockerLabel": "Calendar friction for workout scheduling",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "context-loss",
+      "blockerLabel": "Loses relationship context between sessions",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "dependency-uncertainty",
+      "blockerLabel": "Unclear owner for pending dependencies",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "constraint-conflict",
+      "blockerLabel": "Conflicting constraints are not surfaced early",
+      "count": 1,
+      "recurringCount": 1
+    },
+    {
+      "blockerId": "sleep-plan-drift",
+      "blockerLabel": "Bedtime plan drifts after evening meetings",
+      "count": 1,
+      "recurringCount": 0
+    },
+    {
+      "blockerId": "timing-mismatch",
+      "blockerLabel": "Outreach timing mismatches recipient preferences",
+      "count": 1,
+      "recurringCount": 0
+    }
+  ],
+  "capabilityProposals": [
+    {
+      "capabilityGap": "constraint_resolution",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.91,
+      "impactedScenarios": [
+        "contradictory_requests"
+      ],
+      "recommendationScore": 0.7995
+    },
+    {
+      "capabilityGap": "email_prioritization",
+      "evidenceCount": 2,
+      "recurringEvidenceCount": 2,
+      "averageSeverity": 0.805,
+      "impactedScenarios": [
+        "work_income",
+        "stalled_loops"
+      ],
+      "recommendationScore": 0.7923
+    },
+    {
+      "capabilityGap": "dependency_mapping",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.89,
+      "impactedScenarios": [
+        "stalled_loops"
+      ],
+      "recommendationScore": 0.7905
+    },
+    {
+      "capabilityGap": "calendar_orchestration",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.8,
+      "impactedScenarios": [
+        "health_performance"
+      ],
+      "recommendationScore": 0.75
+    },
+    {
+      "capabilityGap": "relationship_memory_synthesis",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.78,
+      "impactedScenarios": [
+        "relationships_networking"
+      ],
+      "recommendationScore": 0.741
+    },
+    {
+      "capabilityGap": "artifact_consolidation",
+      "evidenceCount": 2,
+      "recurringEvidenceCount": 1,
+      "averageSeverity": 0.71,
+      "impactedScenarios": [
+        "work_income",
+        "contradictory_requests"
+      ],
+      "recommendationScore": 0.5745
+    },
+    {
+      "capabilityGap": "timing_personalization",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 0,
+      "averageSeverity": 0.64,
+      "impactedScenarios": [
+        "relationships_networking"
+      ],
+      "recommendationScore": 0.328
+    },
+    {
+      "capabilityGap": "circadian_routine_adjustment",
+      "evidenceCount": 1,
+      "recurringEvidenceCount": 0,
+      "averageSeverity": 0.62,
+      "impactedScenarios": [
+        "health_performance"
+      ],
+      "recommendationScore": 0.319
+    }
+  ],
+  "skillHealth": [
+    {
+      "skillId": "pipeline-prioritization",
+      "successRate": 0.8571,
+      "totalAttempts": 7,
+      "trend": "promote"
+    },
+    {
+      "skillId": "habit-planning",
+      "successRate": 0.8333,
+      "totalAttempts": 6,
+      "trend": "promote"
+    },
+    {
+      "skillId": "follow-up-cadence",
+      "successRate": 0.8,
+      "totalAttempts": 5,
+      "trend": "promote"
+    },
+    {
+      "skillId": "conversation-briefing",
+      "successRate": 0.75,
+      "totalAttempts": 4,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "campaign-reset",
+      "successRate": 0.6,
+      "totalAttempts": 5,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "approval-routing",
+      "successRate": 0.6,
+      "totalAttempts": 5,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "nutrition-basics",
+      "successRate": 0.5,
+      "totalAttempts": 4,
+      "trend": "maintain"
+    },
+    {
+      "skillId": "meeting-prep",
+      "successRate": 0.4,
+      "totalAttempts": 5,
+      "trend": "decay"
+    },
+    {
+      "skillId": "dependency-resolution",
+      "successRate": 0.3333,
+      "totalAttempts": 6,
+      "trend": "decay"
+    },
+    {
+      "skillId": "constraint-clarification",
+      "successRate": 0.3333,
+      "totalAttempts": 6,
+      "trend": "decay"
+    }
+  ],
+  "summary": {
+    "mostRecurringBlocker": "inbox-overload",
+    "topCapabilityUpgrade": "constraint_resolution",
+    "campaignLoopTrend": "flat_or_declining"
+  }
+}

--- a/artifacts/life-os/latest-improvement-artifacts.json
+++ b/artifacts/life-os/latest-improvement-artifacts.json
@@ -1,0 +1,20 @@
+{
+  "generatedAt": "2026-04-15T21:52:53.433Z",
+  "topRecurringBlockers": [
+    "inbox-overload",
+    "proposal-fragmentation",
+    "calendar-friction"
+  ],
+  "capabilityUpgradeRecommendation": "constraint_resolution",
+  "promotedSkills": [
+    "pipeline-prioritization",
+    "habit-planning",
+    "follow-up-cadence"
+  ],
+  "decayedSkills": [
+    "meeting-prep",
+    "dependency-resolution",
+    "constraint-clarification"
+  ],
+  "campaignLoopTrend": "flat_or_declining"
+}

--- a/docs/LIFE_OS_EVALS.md
+++ b/docs/LIFE_OS_EVALS.md
@@ -1,0 +1,34 @@
+# Life OS Eval Loop
+
+This repo now includes a deterministic eval loop that can be run locally to evaluate loop quality and generate improvement artifacts.
+
+## What is included
+
+- eval fixtures for:
+  - health/performance
+  - work/income
+  - relationships/networking
+  - stalled loops
+  - contradictory requests
+- metrics:
+  - loop closure rate
+  - unnecessary question rate
+  - approval correctness
+  - memory usefulness
+  - intervention usefulness
+  - blocker recurrence
+- capability proposal ranking based on recurring blockers and severity
+- skill promotion/decay rules based on repeated outcomes
+- persistent reports and improvement artifacts in `artifacts/life-os/`
+
+## Run
+
+```bash
+npm run evals:life-os
+```
+
+## Outputs
+
+- `artifacts/life-os/latest-eval-report.json`
+- `artifacts/life-os/latest-improvement-artifacts.json`
+- timestamped historical snapshots for each run

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "generate:sitemap": "tsx scripts/generate-sitemap.ts",
     "report:weekly-ops": "tsx scripts/analytics/generate-weekly-operating-report.ts",
     "export:supabase-seed": "tsx scripts/export-supabase-seed.ts",
-    "sync:supabase": "tsx scripts/sync-supabase.ts"
+    "sync:supabase": "tsx scripts/sync-supabase.ts",
+    "evals:life-os": "tsx scripts/run-life-os-evals.ts"
   },
   "dependencies": {
     "@google/genai": "^1.29.0",

--- a/scripts/run-life-os-evals.ts
+++ b/scripts/run-life-os-evals.ts
@@ -1,0 +1,59 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { buildEvalReport } from '@/src/lib/lifeOsEvalEngine';
+import { LIFE_OS_EVAL_FIXTURES } from '@/src/lib/lifeOsEvalFixtures';
+
+interface ImprovementArtifact {
+  generatedAt: string;
+  topRecurringBlockers: string[];
+  capabilityUpgradeRecommendation: string | null;
+  promotedSkills: string[];
+  decayedSkills: string[];
+  campaignLoopTrend: 'improving' | 'flat_or_declining';
+}
+
+const ARTIFACT_ROOT = path.resolve('artifacts/life-os');
+const LATEST_REPORT_PATH = path.join(ARTIFACT_ROOT, 'latest-eval-report.json');
+const LATEST_IMPROVEMENT_PATH = path.join(ARTIFACT_ROOT, 'latest-improvement-artifacts.json');
+
+function toImprovementArtifact(report: ReturnType<typeof buildEvalReport>): ImprovementArtifact {
+  return {
+    generatedAt: report.generatedAt,
+    topRecurringBlockers: report.topRecurringBlockers.slice(0, 3).map((blocker) => blocker.blockerId),
+    capabilityUpgradeRecommendation: report.summary.topCapabilityUpgrade,
+    promotedSkills: report.skillHealth.filter((skill) => skill.trend === 'promote').map((skill) => skill.skillId),
+    decayedSkills: report.skillHealth.filter((skill) => skill.trend === 'decay').map((skill) => skill.skillId),
+    campaignLoopTrend: report.summary.campaignLoopTrend
+  };
+}
+
+async function persistEvalArtifacts(): Promise<void> {
+  const report = buildEvalReport(LIFE_OS_EVAL_FIXTURES);
+  const timestampSlug = report.generatedAt.replaceAll(':', '-');
+  const historicalReportPath = path.join(ARTIFACT_ROOT, `eval-report-${timestampSlug}.json`);
+  const historicalImprovementPath = path.join(ARTIFACT_ROOT, `improvement-artifacts-${timestampSlug}.json`);
+
+  const improvementArtifact = toImprovementArtifact(report);
+
+  await mkdir(ARTIFACT_ROOT, { recursive: true });
+
+  const writes = [
+    writeFile(LATEST_REPORT_PATH, JSON.stringify(report, null, 2)),
+    writeFile(historicalReportPath, JSON.stringify(report, null, 2)),
+    writeFile(LATEST_IMPROVEMENT_PATH, JSON.stringify(improvementArtifact, null, 2)),
+    writeFile(historicalImprovementPath, JSON.stringify(improvementArtifact, null, 2))
+  ];
+
+  await Promise.all(writes);
+
+  console.log(`Saved report to ${LATEST_REPORT_PATH}`);
+  console.log(`Saved improvement artifacts to ${LATEST_IMPROVEMENT_PATH}`);
+  console.log(`Top recurring blocker: ${report.summary.mostRecurringBlocker ?? 'none'}`);
+  console.log(`Recommended capability upgrade: ${report.summary.topCapabilityUpgrade ?? 'none'}`);
+}
+
+persistEvalArtifacts().catch((error: unknown) => {
+  console.error('Failed to run Life OS eval artifacts generation.', error);
+  process.exitCode = 1;
+});

--- a/src/lib/lifeOsEvalEngine.ts
+++ b/src/lib/lifeOsEvalEngine.ts
@@ -1,0 +1,248 @@
+import type { EvalFixture } from '@/src/lib/lifeOsEvalFixtures';
+
+export interface EvalMetricSet {
+  loopClosureRate: number;
+  unnecessaryQuestionRate: number;
+  approvalCorrectnessRate: number;
+  memoryUsefulnessRate: number;
+  interventionUsefulnessRate: number;
+  blockerRecurrenceRate: number;
+}
+
+export interface CapabilityProposal {
+  capabilityGap: string;
+  evidenceCount: number;
+  recurringEvidenceCount: number;
+  averageSeverity: number;
+  impactedScenarios: string[];
+  recommendationScore: number;
+}
+
+export interface SkillHealth {
+  skillId: string;
+  successRate: number;
+  totalAttempts: number;
+  trend: 'promote' | 'decay' | 'maintain';
+}
+
+export interface EvalReport {
+  generatedAt: string;
+  fixtureCount: number;
+  metrics: EvalMetricSet;
+  topRecurringBlockers: Array<{
+    blockerId: string;
+    blockerLabel: string;
+    count: number;
+    recurringCount: number;
+  }>;
+  capabilityProposals: CapabilityProposal[];
+  skillHealth: SkillHealth[];
+  summary: {
+    mostRecurringBlocker: string | null;
+    topCapabilityUpgrade: string | null;
+    campaignLoopTrend: 'improving' | 'flat_or_declining';
+  };
+}
+
+const DECIMAL_PRECISION = 4;
+
+function safeRate(numerator: number, denominator: number): number {
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  return Number((numerator / denominator).toFixed(DECIMAL_PRECISION));
+}
+
+export function computeEvalMetrics(fixtures: EvalFixture[]): EvalMetricSet {
+  const totals = fixtures.reduce(
+    (acc, fixture) => {
+      acc.totalLoops += fixture.totalLoops;
+      acc.closedLoops += fixture.closedLoops;
+      acc.questionsAsked += fixture.questionsAsked;
+      acc.unnecessaryQuestions += fixture.unnecessaryQuestions;
+      acc.approvalDecisions += fixture.approvalDecisions;
+      acc.approvalsCorrect += fixture.approvalsCorrect;
+      acc.memoryLookups += fixture.memoryLookups;
+      acc.helpfulMemoryRecalls += fixture.helpfulMemoryRecalls;
+      acc.interventions += fixture.interventions;
+      acc.successfulInterventions += fixture.successfulInterventions;
+      acc.totalBlockers += fixture.blockers.length;
+      acc.recurringBlockers += fixture.blockers.filter((blocker) => blocker.recurred).length;
+
+      return acc;
+    },
+    {
+      totalLoops: 0,
+      closedLoops: 0,
+      questionsAsked: 0,
+      unnecessaryQuestions: 0,
+      approvalDecisions: 0,
+      approvalsCorrect: 0,
+      memoryLookups: 0,
+      helpfulMemoryRecalls: 0,
+      interventions: 0,
+      successfulInterventions: 0,
+      totalBlockers: 0,
+      recurringBlockers: 0
+    }
+  );
+
+  return {
+    loopClosureRate: safeRate(totals.closedLoops, totals.totalLoops),
+    unnecessaryQuestionRate: safeRate(totals.unnecessaryQuestions, totals.questionsAsked),
+    approvalCorrectnessRate: safeRate(totals.approvalsCorrect, totals.approvalDecisions),
+    memoryUsefulnessRate: safeRate(totals.helpfulMemoryRecalls, totals.memoryLookups),
+    interventionUsefulnessRate: safeRate(totals.successfulInterventions, totals.interventions),
+    blockerRecurrenceRate: safeRate(totals.recurringBlockers, totals.totalBlockers)
+  };
+}
+
+export function rankCapabilityProposals(fixtures: EvalFixture[]): CapabilityProposal[] {
+  const proposals = new Map<string, CapabilityProposal>();
+
+  fixtures.forEach((fixture) => {
+    fixture.blockers.forEach((blocker) => {
+      const existing = proposals.get(blocker.capabilityGap);
+      const recurringDelta = blocker.recurred ? 1 : 0;
+
+      if (!existing) {
+        proposals.set(blocker.capabilityGap, {
+          capabilityGap: blocker.capabilityGap,
+          evidenceCount: 1,
+          recurringEvidenceCount: recurringDelta,
+          averageSeverity: blocker.severity,
+          impactedScenarios: [fixture.scenario],
+          recommendationScore: 0
+        });
+        return;
+      }
+
+      const totalSeverity = (existing.averageSeverity * existing.evidenceCount) + blocker.severity;
+      existing.evidenceCount += 1;
+      existing.recurringEvidenceCount += recurringDelta;
+      existing.averageSeverity = Number((totalSeverity / existing.evidenceCount).toFixed(DECIMAL_PRECISION));
+
+      if (!existing.impactedScenarios.includes(fixture.scenario)) {
+        existing.impactedScenarios.push(fixture.scenario);
+      }
+    });
+  });
+
+  const ranked = Array.from(proposals.values()).map((proposal) => {
+    const recurrenceWeight = safeRate(proposal.recurringEvidenceCount, Math.max(proposal.evidenceCount, 1));
+    const impactWeight = safeRate(proposal.impactedScenarios.length, fixtures.length || 1);
+
+    proposal.recommendationScore = Number((
+      (proposal.averageSeverity * 0.45) +
+      (recurrenceWeight * 0.35) +
+      (impactWeight * 0.2)
+    ).toFixed(DECIMAL_PRECISION));
+
+    return proposal;
+  });
+
+  return ranked.sort((a, b) => {
+    if (b.recommendationScore !== a.recommendationScore) {
+      return b.recommendationScore - a.recommendationScore;
+    }
+
+    return b.recurringEvidenceCount - a.recurringEvidenceCount;
+  });
+}
+
+export function deriveSkillHealth(fixtures: EvalFixture[]): SkillHealth[] {
+  const skillMap = new Map<string, { successfulUses: number; failedUses: number }>();
+
+  fixtures.forEach((fixture) => {
+    fixture.skills.forEach((skill) => {
+      const existing = skillMap.get(skill.skillId) ?? { successfulUses: 0, failedUses: 0 };
+      existing.successfulUses += skill.successfulUses;
+      existing.failedUses += skill.failedUses;
+      skillMap.set(skill.skillId, existing);
+    });
+  });
+
+  const health: SkillHealth[] = Array.from(skillMap.entries()).map(([skillId, stats]) => {
+    const totalAttempts = stats.successfulUses + stats.failedUses;
+    const successRate = safeRate(stats.successfulUses, totalAttempts);
+
+    let trend: SkillHealth['trend'] = 'maintain';
+    if (totalAttempts >= 5 && successRate >= 0.75) {
+      trend = 'promote';
+    } else if (totalAttempts >= 4 && successRate <= 0.45) {
+      trend = 'decay';
+    }
+
+    return {
+      skillId,
+      successRate,
+      totalAttempts,
+      trend
+    };
+  });
+
+  return health.sort((a, b) => {
+    if (a.trend === b.trend) {
+      return b.successRate - a.successRate;
+    }
+
+    const trendPriority: Record<SkillHealth['trend'], number> = {
+      promote: 0,
+      maintain: 1,
+      decay: 2
+    };
+
+    return trendPriority[a.trend] - trendPriority[b.trend];
+  });
+}
+
+export function buildEvalReport(fixtures: EvalFixture[], generatedAt = new Date().toISOString()): EvalReport {
+  const metrics = computeEvalMetrics(fixtures);
+  const capabilityProposals = rankCapabilityProposals(fixtures);
+  const skillHealth = deriveSkillHealth(fixtures);
+
+  const blockerCountMap = new Map<string, { blockerLabel: string; count: number; recurringCount: number }>();
+  fixtures.forEach((fixture) => {
+    fixture.blockers.forEach((blocker) => {
+      const current = blockerCountMap.get(blocker.blockerId) ?? {
+        blockerLabel: blocker.blockerLabel,
+        count: 0,
+        recurringCount: 0
+      };
+
+      current.count += 1;
+      if (blocker.recurred) {
+        current.recurringCount += 1;
+      }
+
+      blockerCountMap.set(blocker.blockerId, current);
+    });
+  });
+
+  const topRecurringBlockers = Array.from(blockerCountMap.entries())
+    .map(([blockerId, value]) => ({ blockerId, ...value }))
+    .sort((a, b) => {
+      if (b.recurringCount !== a.recurringCount) {
+        return b.recurringCount - a.recurringCount;
+      }
+
+      return b.count - a.count;
+    });
+
+  return {
+    generatedAt,
+    fixtureCount: fixtures.length,
+    metrics,
+    topRecurringBlockers,
+    capabilityProposals,
+    skillHealth,
+    summary: {
+      mostRecurringBlocker: topRecurringBlockers[0]?.blockerId ?? null,
+      topCapabilityUpgrade: capabilityProposals[0]?.capabilityGap ?? null,
+      campaignLoopTrend: metrics.loopClosureRate >= 0.6 && metrics.interventionUsefulnessRate >= 0.55
+        ? 'improving'
+        : 'flat_or_declining'
+    }
+  };
+}

--- a/src/lib/lifeOsEvalFixtures.ts
+++ b/src/lib/lifeOsEvalFixtures.ts
@@ -1,0 +1,216 @@
+export type EvalFixtureScenario =
+  | 'health_performance'
+  | 'work_income'
+  | 'relationships_networking'
+  | 'stalled_loops'
+  | 'contradictory_requests';
+
+export interface BlockerEvidence {
+  blockerId: string;
+  blockerLabel: string;
+  capabilityGap: string;
+  severity: number;
+  recurred: boolean;
+}
+
+export interface SkillUseEvidence {
+  skillId: string;
+  successfulUses: number;
+  failedUses: number;
+}
+
+export interface EvalFixture {
+  id: string;
+  scenario: EvalFixtureScenario;
+  goals: string[];
+  totalLoops: number;
+  closedLoops: number;
+  questionsAsked: number;
+  unnecessaryQuestions: number;
+  approvalDecisions: number;
+  approvalsCorrect: number;
+  memoryLookups: number;
+  helpfulMemoryRecalls: number;
+  interventions: number;
+  successfulInterventions: number;
+  blockers: BlockerEvidence[];
+  skills: SkillUseEvidence[];
+}
+
+export const LIFE_OS_EVAL_FIXTURES: EvalFixture[] = [
+  {
+    id: 'fixture-health-performance',
+    scenario: 'health_performance',
+    goals: ['Increase weekly exercise consistency', 'Improve sleep timing'],
+    totalLoops: 9,
+    closedLoops: 6,
+    questionsAsked: 18,
+    unnecessaryQuestions: 3,
+    approvalDecisions: 5,
+    approvalsCorrect: 4,
+    memoryLookups: 8,
+    helpfulMemoryRecalls: 6,
+    interventions: 7,
+    successfulInterventions: 5,
+    blockers: [
+      {
+        blockerId: 'calendar-friction',
+        blockerLabel: 'Calendar friction for workout scheduling',
+        capabilityGap: 'calendar_orchestration',
+        severity: 0.8,
+        recurred: true
+      },
+      {
+        blockerId: 'sleep-plan-drift',
+        blockerLabel: 'Bedtime plan drifts after evening meetings',
+        capabilityGap: 'circadian_routine_adjustment',
+        severity: 0.62,
+        recurred: false
+      }
+    ],
+    skills: [
+      { skillId: 'habit-planning', successfulUses: 5, failedUses: 1 },
+      { skillId: 'nutrition-basics', successfulUses: 2, failedUses: 2 }
+    ]
+  },
+  {
+    id: 'fixture-work-income',
+    scenario: 'work_income',
+    goals: ['Ship proposal faster', 'Improve lead follow-up cadence'],
+    totalLoops: 11,
+    closedLoops: 7,
+    questionsAsked: 22,
+    unnecessaryQuestions: 4,
+    approvalDecisions: 6,
+    approvalsCorrect: 5,
+    memoryLookups: 10,
+    helpfulMemoryRecalls: 7,
+    interventions: 9,
+    successfulInterventions: 6,
+    blockers: [
+      {
+        blockerId: 'inbox-overload',
+        blockerLabel: 'Inbox overload hides high-value leads',
+        capabilityGap: 'email_prioritization',
+        severity: 0.84,
+        recurred: true
+      },
+      {
+        blockerId: 'proposal-fragmentation',
+        blockerLabel: 'Proposal artifacts are scattered across tools',
+        capabilityGap: 'artifact_consolidation',
+        severity: 0.73,
+        recurred: true
+      }
+    ],
+    skills: [
+      { skillId: 'pipeline-prioritization', successfulUses: 6, failedUses: 1 },
+      { skillId: 'meeting-prep', successfulUses: 2, failedUses: 3 }
+    ]
+  },
+  {
+    id: 'fixture-relationships-networking',
+    scenario: 'relationships_networking',
+    goals: ['Reduce missed follow-ups', 'Increase meaningful check-ins'],
+    totalLoops: 8,
+    closedLoops: 5,
+    questionsAsked: 14,
+    unnecessaryQuestions: 2,
+    approvalDecisions: 4,
+    approvalsCorrect: 3,
+    memoryLookups: 9,
+    helpfulMemoryRecalls: 8,
+    interventions: 6,
+    successfulInterventions: 4,
+    blockers: [
+      {
+        blockerId: 'context-loss',
+        blockerLabel: 'Loses relationship context between sessions',
+        capabilityGap: 'relationship_memory_synthesis',
+        severity: 0.78,
+        recurred: true
+      },
+      {
+        blockerId: 'timing-mismatch',
+        blockerLabel: 'Outreach timing mismatches recipient preferences',
+        capabilityGap: 'timing_personalization',
+        severity: 0.64,
+        recurred: false
+      }
+    ],
+    skills: [
+      { skillId: 'follow-up-cadence', successfulUses: 4, failedUses: 1 },
+      { skillId: 'conversation-briefing', successfulUses: 3, failedUses: 1 }
+    ]
+  },
+  {
+    id: 'fixture-stalled-loops',
+    scenario: 'stalled_loops',
+    goals: ['Restart dormant campaigns', 'Clear dependency bottlenecks'],
+    totalLoops: 12,
+    closedLoops: 6,
+    questionsAsked: 20,
+    unnecessaryQuestions: 6,
+    approvalDecisions: 7,
+    approvalsCorrect: 4,
+    memoryLookups: 7,
+    helpfulMemoryRecalls: 4,
+    interventions: 10,
+    successfulInterventions: 5,
+    blockers: [
+      {
+        blockerId: 'dependency-uncertainty',
+        blockerLabel: 'Unclear owner for pending dependencies',
+        capabilityGap: 'dependency_mapping',
+        severity: 0.89,
+        recurred: true
+      },
+      {
+        blockerId: 'inbox-overload',
+        blockerLabel: 'Inbox overload hides high-value leads',
+        capabilityGap: 'email_prioritization',
+        severity: 0.77,
+        recurred: true
+      }
+    ],
+    skills: [
+      { skillId: 'dependency-resolution', successfulUses: 2, failedUses: 4 },
+      { skillId: 'campaign-reset', successfulUses: 3, failedUses: 2 }
+    ]
+  },
+  {
+    id: 'fixture-contradictory-requests',
+    scenario: 'contradictory_requests',
+    goals: ['Resolve conflicting constraints with fewer retries'],
+    totalLoops: 7,
+    closedLoops: 4,
+    questionsAsked: 17,
+    unnecessaryQuestions: 5,
+    approvalDecisions: 5,
+    approvalsCorrect: 3,
+    memoryLookups: 6,
+    helpfulMemoryRecalls: 3,
+    interventions: 8,
+    successfulInterventions: 4,
+    blockers: [
+      {
+        blockerId: 'constraint-conflict',
+        blockerLabel: 'Conflicting constraints are not surfaced early',
+        capabilityGap: 'constraint_resolution',
+        severity: 0.91,
+        recurred: true
+      },
+      {
+        blockerId: 'proposal-fragmentation',
+        blockerLabel: 'Proposal artifacts are scattered across tools',
+        capabilityGap: 'artifact_consolidation',
+        severity: 0.69,
+        recurred: false
+      }
+    ],
+    skills: [
+      { skillId: 'constraint-clarification', successfulUses: 2, failedUses: 4 },
+      { skillId: 'approval-routing', successfulUses: 3, failedUses: 2 }
+    ]
+  }
+];


### PR DESCRIPTION
### Motivation

- Close the Life OS learning loop by adding deterministic eval fixtures and automated reporting to measure loop quality and recurring blockers. 
- Provide evidence-based capability proposals and a simple self-improvement signal (skill promote/decay) tied to observed outcomes. 
- Persist improvement artifacts so trends and upgrade recommendations can be tracked over time. 

### Description

- Added deterministic eval fixtures in `src/lib/lifeOsEvalFixtures.ts` covering the five scenarios: `health_performance`, `work_income`, `relationships_networking`, `stalled_loops`, and `contradictory_requests`.
- Implemented an eval engine at `src/lib/lifeOsEvalEngine.ts` that computes metrics (loop closure, unnecessary-question rate, approval correctness, memory usefulness, intervention usefulness, blocker recurrence), ranks capability proposals by severity/recurrence/impact, and derives skill health trends (`promote`/`decay`/`maintain`).
- Added a runner script `scripts/run-life-os-evals.ts` and an `npm` script `evals:life-os` that persists both latest and timestamped reports to `artifacts/life-os/` and emits a compact improvement artifact (top blockers, recommended capability upgrade, promoted/decayed skills).
- Added documentation `docs/LIFE_OS_EVALS.md` describing usage and outputs. 

### Testing

- Ran `npm run evals:life-os` which generated `artifacts/life-os/latest-eval-report.json` and `artifacts/life-os/latest-improvement-artifacts.json` and completed successfully. 
- Ran `npm run lint` (`tsc --noEmit`) with no type errors. 
- Ran `npm run build` (`vite build`) and the production build completed and passed the configured build budget checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e007ce5c1c8320b13be81e288e070d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluation system assessing performance across health/performance, work/income, relationships, stalled loops, and contradictory requests scenarios
  * Generates aggregated performance metrics, capability upgrade recommendations, skill health tracking, and improvement artifacts with recurring blocker identification
  * Persistent evaluation reports stored with timestamped historical snapshots

* **Documentation**
  * Added evaluation system documentation guide

* **Chores**
  * Added npm command for running evaluations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->