### PR TITLE
Fix claim flow: stale approved-claim flag, back-button desync, error handling

### DIFF
--- a/src/pages/AdminClaimsPage.tsx
+++ b/src/pages/AdminClaimsPage.tsx
@@ -293,6 +293,8 @@ export default function AdminClaimsPage() {
       const review = await supabase.rpc('review_business_claim', { p_claim_id: claimId, p_status: status, p_rejection_reason: reason });
       if (review.error) {
         setError(review.error.message);
+        // The claim may have been reviewed by someone else (P1013); resync the list.
+        await fetchClaims({ silent: true });
         return;
       }
 

--- a/src/pages/AdminClaimsPage.tsx
+++ b/src/pages/AdminClaimsPage.tsx
@@ -292,18 +292,19 @@ export default function AdminClaimsPage() {
     try {
       const review = await supabase.rpc('review_business_claim', { p_claim_id: claimId, p_status: status, p_rejection_reason: reason });
       if (review.error) {
-        setError(review.error.message);
-        // The claim may have been reviewed by someone else (P1013); resync the list.
+        // The claim may have been reviewed by someone else (P1013); resync the list
+        // before setting the error, since fetchClaims clears errors on success.
         await fetchClaims({ silent: true });
+        setError(review.error.message);
         return;
       }
 
       setRejectionReason((current) => ({ ...current, [claimId]: '' }));
       const notify = await supabase.functions.invoke('notify_claim_status', { body: { claim_id: claimId } });
+      await fetchClaims({ silent: true });
       if (notify.error) {
         setError(`Claim ${status} but notification dispatch reported an error: ${notify.error.message}`);
       }
-      await fetchClaims({ silent: true });
     } finally {
       setProcessingId(null);
     }

--- a/src/pages/ClaimPage.tsx
+++ b/src/pages/ClaimPage.tsx
@@ -121,7 +121,14 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
   const targetedBusinessCategoryName = targetedBusiness ? categoryNames.get(targetedBusiness.categoryId) : undefined;
 
   useEffect(() => {
-    if (!user || directoryLoading || !selectedBusinessId) {
+    if (!user || directoryLoading) {
+      return;
+    }
+
+    if (!selectedBusinessId) {
+      // Keep the wizard in sync with the URL (e.g. browser back from step 2).
+      setSelectedBusiness(null);
+      setStep(1);
       return;
     }
 
@@ -369,7 +376,9 @@ export default function ClaimPage({ onClaimComplete }: ClaimPageProps) {
           return;
         }
 
-        if (code === 'P0001' || msg.toLowerCase().includes('not authenticated')) {
+        // P0001 alone is not specific: it is the default SQLSTATE for any unqualified
+        // `raise exception` in the claim RPC, so match on the message instead.
+        if (msg.toLowerCase().includes('not authenticated')) {
           setError('Your session expired. Please sign in again and resubmit your claim.');
           return;
         }

--- a/src/pages/ClaimStatusPage.tsx
+++ b/src/pages/ClaimStatusPage.tsx
@@ -73,7 +73,7 @@ function getPaidIntentFromHref(href?: string) {
 
 export default function ClaimStatusPage() {
   const [searchParams] = useSearchParams();
-  const { user, loading: authLoading } = useAuth();
+  const { user, loading: authLoading, hasApprovedClaim, refreshProfile } = useAuth();
   const { businesses, isLoading: directoryLoading } = useDirectoryData();
   const [claims, setClaims] = useState<BusinessClaim[]>([]);
   const [loading, setLoading] = useState(true);
@@ -81,6 +81,7 @@ export default function ClaimStatusPage() {
   const [evidenceSignedUrls, setEvidenceSignedUrls] = useState<Record<string, string[]>>({});
   const claimsAvailable = Boolean(supabase && isSupabaseConfigured());
   const trackedRecommendationViews = useRef(new Set<string>());
+  const attemptedClaimFlagRefresh = useRef(false);
   const showSubmittedBanner = searchParams.get('submitted') === '1';
   const pageSeo = (
     <Seo
@@ -173,8 +174,27 @@ export default function ClaimStatusPage() {
         } else {
           const nextClaims = (data ?? []) as BusinessClaim[];
           setClaims(nextClaims);
-          const evidenceUrlsMap = await createEvidenceSignedUrlMap(supabase, nextClaims);
-          setEvidenceSignedUrls(evidenceUrlsMap);
+
+          // The auth context caches hasApprovedClaim at sign-in. If an admin approved a
+          // claim since then, refresh it so AuthGuard stops bouncing the owner dashboard
+          // link back to this page.
+          if (
+            !attemptedClaimFlagRefresh.current
+            && !hasApprovedClaim
+            && nextClaims.some((claim) => claim.status === 'approved')
+          ) {
+            attemptedClaimFlagRefresh.current = true;
+            void refreshProfile();
+          }
+
+          try {
+            const evidenceUrlsMap = await createEvidenceSignedUrlMap(supabase, nextClaims);
+            setEvidenceSignedUrls(evidenceUrlsMap);
+          } catch (evidenceError) {
+            // Evidence links are secondary; never block the status page on them.
+            console.error('Failed to create evidence signed URLs:', evidenceError);
+            setEvidenceSignedUrls({});
+          }
         }
       } catch (caughtError) {
         setError(caughtError instanceof Error ? caughtError.message : 'Failed to load claims.');
@@ -184,7 +204,8 @@ export default function ClaimStatusPage() {
     }
 
     fetchClaims();
-  }, [claimsAvailable, user]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refetch only when the signed-in user changes, not on token refresh
+  }, [claimsAvailable, user?.id]);
 
   if (authLoading || loading || directoryLoading) {
     return (


### PR DESCRIPTION
## Motivation
The business claim flow had a flow-breaking bug plus several smaller correctness issues found in a full audit of the claim pages, RPCs, and edge functions.

## The flow-breaking bug
`AuthContext` caches `hasApprovedClaim` when the session is established. When an admin approves a claim afterwards, the owner's context still says `false`, so `AuthGuard requireApprovedClaim` bounces every click of **Open owner dashboard** straight back to `/claim/status`. The flow only healed on a full page reload or token refresh.

**Fix:** `ClaimStatusPage` now refreshes the cached flag (via `refreshProfile()`) whenever it fetches a claim that is approved while the context still says no approved claim exists. Since the bounce target *is* the status page, this also self-heals the redirect loop.

## Other fixes
- **ClaimStatusPage**: a failure creating evidence signed URLs used to set the page-level error state and replace the entire status page with an error screen even though claims had loaded. Evidence link generation is now non-fatal.
- **ClaimStatusPage**: the claims fetch effect depended on the `user` object identity, refetching claims and re-signing every evidence URL on each token refresh. Now keyed on `user?.id`.
- **ClaimPage**: pressing browser Back from step 2 (owner details) removed `businessId` from the URL but left the UI on step 2. The URL-sync effect now resets the wizard to search when the param is gone.
- **ClaimPage**: `code === 'P0001'` was treated as "session expired", but P0001 is the default SQLSTATE for *any* unqualified `raise exception` in the RPC (e.g. 'Relationship to business is required'). Now matches the 'not authenticated' message instead.
- **AdminClaimsPage**: when `review_business_claim` fails (e.g. P1013 because another admin already reviewed the claim), the list is now resynced so the admin isn't acting on stale data.

## Testing
- `npx tsc --noEmit` passes with no errors
- `npm run build` completes; build budget check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Claim review now automatically refreshes the claims list when errors occur
* Improved session expiration detection for better authentication handling
* Evidence link failures no longer block the claims status page
* Fixed wizard navigation issues when business information is missing from URL
* Profile automatically refreshes when an approved claim is confirmed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->