### PR TITLE
Worker profiles, jobs board, and resume onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^17.2.3",
         "express": "^4.21.2",
         "lucide-react": "^0.546.0",
+        "mammoth": "^1.12.0",
         "motion": "^12.35.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1732,6 +1733,15 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1752,6 +1762,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/array-flatten": {
@@ -1888,6 +1907,12 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -2116,6 +2141,12 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -2194,6 +2225,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -2204,6 +2241,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2858,6 +2904,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2878,6 +2930,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2927,6 +2985,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -2946,6 +3046,15 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3203,6 +3312,17 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3228,6 +3348,30 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3540,6 +3684,12 @@
         "wrappy": "1"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -3553,6 +3703,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3560,6 +3716,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3657,6 +3822,12 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/protobufjs": {
       "version": "7.5.4",
@@ -4028,6 +4199,12 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -4172,6 +4349,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -4403,6 +4586,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -5051,6 +5240,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dotenv": "^17.2.3",
     "express": "^4.21.2",
     "lucide-react": "^0.546.0",
+    "mammoth": "^1.12.0",
     "motion": "^12.35.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,14 @@ const TradesPage = lazy(() => import('./pages/TradesPage'));
 const RegionsPage = lazy(() => import('./pages/RegionsPage'));
 const VerifiedPage = lazy(() => import('./pages/VerifiedPage'));
 const SearchPage = lazy(() => import('./pages/SearchPage'));
+const ClassifiedsPage = lazy(() => import('./pages/ClassifiedsPage'));
+const ClassifiedsPostPage = lazy(() => import('./pages/ClassifiedsPostPage'));
+const ClassifiedsSubmittedPage = lazy(() => import('./pages/ClassifiedsSubmittedPage'));
+const WorkersPage = lazy(() => import('./pages/WorkersPage'));
+const WorkerProfilePage = lazy(() => import('./pages/WorkerProfilePage'));
+const WorkerOnboardingPage = lazy(() => import('./pages/WorkerOnboardingPage'));
+const WorkerDashboardPage = lazy(() => import('./pages/WorkerDashboardPage'));
+const AdminWorkerProfilesPage = lazy(() => import('./pages/AdminWorkerProfilesPage'));
 const TermsPage = lazy(() => import('./pages/TermsPage'));
 const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
 const ContactPage = lazy(() => import('./pages/ContactPage'));
@@ -35,6 +43,7 @@ const LoginPage = lazy(() => import('./pages/LoginPage'));
 const ResetPasswordPage = lazy(() => import('./pages/ResetPasswordPage'));
 const UpdatePasswordPage = lazy(() => import('./pages/UpdatePasswordPage'));
 const AdminClaimsPage = lazy(() => import('./pages/AdminClaimsPage'));
+const AdminClassifiedsPage = lazy(() => import('./pages/AdminClassifiedsPage'));
 
 function ScrollToTop() {
   const location = useLocation();
@@ -77,6 +86,31 @@ function AnimatedRoutes() {
             <Route path="regions" element={<RegionsPage />} />
             <Route path="verified" element={<VerifiedPage />} />
             <Route path="search" element={<SearchPage />} />
+            <Route path="jobs" element={<ClassifiedsPage />} />
+            <Route path="jobs/post" element={<ClassifiedsPostPage />} />
+            <Route path="jobs/submitted" element={<ClassifiedsSubmittedPage />} />
+            <Route path="classifieds" element={<Navigate to="/jobs" replace />} />
+            <Route path="classifieds/post" element={<Navigate to="/jobs/post" replace />} />
+            <Route path="classifieds/submitted" element={<Navigate to="/jobs/submitted" replace />} />
+            <Route path="workers" element={<WorkersPage />} />
+            <Route path="workers/:workerId" element={<WorkerProfilePage />} />
+            <Route path="worker/start" element={<WorkerOnboardingPage />} />
+            <Route
+              path="worker/dashboard"
+              element={
+                <AuthGuard>
+                  <WorkerDashboardPage />
+                </AuthGuard>
+              }
+            />
+            <Route
+              path="admin/workers"
+              element={
+                <AdminGuard>
+                  <AdminWorkerProfilesPage />
+                </AdminGuard>
+              }
+            />
             <Route
               path="claim/status"
               element={
@@ -98,6 +132,14 @@ function AnimatedRoutes() {
               element={
                 <AdminGuard>
                   <AdminClaimsPage />
+                </AdminGuard>
+              }
+            />
+            <Route
+              path="admin/classifieds"
+              element={
+                <AdminGuard>
+                  <AdminClassifiedsPage />
                 </AdminGuard>
               }
             />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,6 +10,8 @@ const primaryLinks = [
   { to: '/trades', label: 'Trades' },
   { to: '/regions', label: 'Regions' },
   { to: '/verified', label: 'Verified' },
+  { to: '/jobs', label: 'Jobs' },
+  { to: '/workers', label: 'Workers' },
 ];
 
 type LayoutChromeContextValue = {
@@ -310,6 +312,9 @@ export default function Layout({ children }: { children: ReactNode }) {
               <h3 className="font-mono text-[10px] tracking-[0.15em] text-zinc-400 mb-4 uppercase font-semibold">For Business</h3>
               <ul className="space-y-3">
                 <li><Link to="/claim" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Claim Your Profile</Link></li>
+                <li><Link to="/jobs" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Jobs</Link></li>
+                <li><Link to="/jobs/post" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Post a Job</Link></li>
+                <li><Link to="/workers" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Workers</Link></li>
                 <li><Link to="/never-miss-a-lead" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Lead Capture System</Link></li>
                 <li><Link to="/websites-for-trades" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Websites for Trades</Link></li>
                 <li><Link to="/managed-growth" className="font-sans text-sm text-zinc-600 hover:text-zinc-900 transition-colors">Managed Growth</Link></li>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useId } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { ChevronDown, User, LogOut, Building, ShieldCheck } from 'lucide-react';
+import { ChevronDown, User, LogOut, Building, ShieldCheck, UserRound } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 interface UserMenuProps {
@@ -104,6 +104,15 @@ export default function UserMenu({ mobile = false }: UserMenuProps) {
             </Link>
           )}
 
+          <Link
+            to="/worker/dashboard"
+            className="flex items-center gap-3 px-4 py-2.5 text-sm text-zinc-600 hover:text-zinc-900 hover:bg-zinc-50 transition-colors"
+            onClick={() => setIsOpen(false)}
+          >
+            <UserRound className="h-4 w-4" strokeWidth={1.5} />
+            Worker Profile
+          </Link>
+
           {profile?.role === 'admin' && (
             <Link
               to="/admin/claims"
@@ -112,6 +121,17 @@ export default function UserMenu({ mobile = false }: UserMenuProps) {
             >
               <ShieldCheck className="h-4 w-4" strokeWidth={1.5} />
               Claims Admin
+            </Link>
+          )}
+
+          {profile?.role === 'admin' && (
+            <Link
+              to="/admin/workers"
+              className="flex items-center gap-3 px-4 py-2.5 text-sm text-zinc-600 hover:text-zinc-900 hover:bg-zinc-50 transition-colors"
+              onClick={() => setIsOpen(false)}
+            >
+              <UserRound className="h-4 w-4" strokeWidth={1.5} />
+              Workers Admin
             </Link>
           )}
 

--- a/src/components/WorkerCard.tsx
+++ b/src/components/WorkerCard.tsx
@@ -1,0 +1,85 @@
+import { Link } from 'react-router-dom';
+import { ArrowRight, Hammer, MapPin, UserRound } from 'lucide-react';
+import { motion } from 'motion/react';
+
+import type { WorkerAvailability, WorkerProfile } from '@/src/lib/workerProfiles';
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 18 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export function availabilityLabel(value: WorkerAvailability) {
+  if (value === 'on_demand') return 'On-demand';
+  if (value === 'short_term') return 'Short-term';
+  return 'Full-time';
+}
+
+interface WorkerCardProps {
+  worker: WorkerProfile;
+  cityName: string;
+  categoryName: string;
+}
+
+export default function WorkerCard({ worker, cityName, categoryName }: WorkerCardProps) {
+  return (
+    <motion.article
+      variants={cardVariants}
+      initial="hidden"
+      animate="visible"
+      transition={{ duration: 0.35 }}
+      className="group flex h-full flex-col overflow-hidden border border-zinc-200 bg-white shadow-sm transition-all hover:shadow-[0_30px_60px_-15px_rgba(0,0,0,0.08)]"
+    >
+      <div className="relative aspect-[4/3] overflow-hidden bg-zinc-100">
+        {worker.photo_url ? (
+          <img
+            src={worker.photo_url}
+            alt={worker.display_name}
+            className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-zinc-300">
+            <UserRound className="h-16 w-16" strokeWidth={1.2} />
+          </div>
+        )}
+        <span className="absolute left-3 top-3 inline-flex items-center border border-orange-200 bg-orange-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-orange-700">
+          {availabilityLabel(worker.availability)}
+        </span>
+      </div>
+
+      <div className="flex flex-1 flex-col p-5">
+        <h2 className="text-xl font-bold leading-tight text-zinc-950">{worker.display_name}</h2>
+        <p className="mt-1 text-sm font-semibold text-zinc-600">{worker.headline}</p>
+
+        <div className="mt-4 grid gap-2 text-sm text-zinc-600">
+          <div className="flex items-center gap-2">
+            <Hammer className="h-4 w-4 text-zinc-400" />
+            <span>{categoryName}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <MapPin className="h-4 w-4 text-zinc-400" />
+            <span>{cityName}</span>
+          </div>
+        </div>
+
+        <div className="mt-3">
+          {worker.rate_label ? (
+            <span className="font-semibold text-zinc-900">{worker.rate_label}</span>
+          ) : (
+            <span className="text-zinc-400">Rate negotiable</span>
+          )}
+        </div>
+
+        <Link
+          to={`/workers/${worker.id}`}
+          className="mt-5 inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-900 bg-zinc-900 px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-white transition-colors hover:bg-zinc-800"
+        >
+          View profile
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+    </motion.article>
+  );
+}

--- a/src/lib/classifieds.ts
+++ b/src/lib/classifieds.ts
@@ -73,7 +73,7 @@ export async function submitClassified(input: ClassifiedInput): Promise<Classifi
       return { success: false, error: 'Add an email or phone number so people can contact you.' };
     }
 
-    const { data, error } = await client
+    const { error } = await client
       .from('classifieds')
       .insert({
         kind: input.kind,
@@ -90,15 +90,13 @@ export async function submitClassified(input: ClassifiedInput): Promise<Classifi
         contact_name: input.contactName.trim(),
         contact_email: contactEmail,
         contact_phone: contactPhone,
-      })
-      .select('id')
-      .single();
+      });
 
     if (error) {
       return { success: false, error: error.message };
     }
 
-    return { success: true, id: data?.id };
+    return { success: true };
   } catch (error) {
     console.error('Classified submission failed:', error);
     return {

--- a/src/lib/classifieds.ts
+++ b/src/lib/classifieds.ts
@@ -1,0 +1,156 @@
+import { isSupabaseConfigured, supabase } from '@/src/lib/supabase';
+
+export type ClassifiedKind = 'job' | 'worker';
+export type ClassifiedStatus = 'pending' | 'approved' | 'rejected' | 'archived';
+export type ClassifiedDurationType = 'on_demand' | 'short_term' | 'full_time';
+
+export interface Classified {
+  id: string;
+  kind: ClassifiedKind;
+  status: ClassifiedStatus;
+  title: string;
+  description: string;
+  city_id: string;
+  category_id: string | null;
+  duration_type: ClassifiedDurationType;
+  organization_name: string | null;
+  compensation_label: string | null;
+  start_date: string | null;
+  end_date: string | null;
+  contact_name: string;
+  contact_email: string | null;
+  contact_phone: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  rejection_reason: string | null;
+  expires_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ClassifiedInput {
+  kind: ClassifiedKind;
+  title: string;
+  description: string;
+  cityId: string;
+  categoryId?: string;
+  durationType: ClassifiedDurationType;
+  organizationName?: string;
+  compensationLabel?: string;
+  startDate?: string;
+  endDate?: string;
+  contactName: string;
+  contactEmail?: string;
+  contactPhone?: string;
+}
+
+export interface ClassifiedResult {
+  success: boolean;
+  id?: string;
+  error?: string;
+}
+
+function optionalText(value?: string) {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function assertSupabase() {
+  if (!isSupabaseConfigured() || !supabase) {
+    throw new Error('Classifieds require a configured Supabase environment.');
+  }
+
+  return supabase;
+}
+
+export async function submitClassified(input: ClassifiedInput): Promise<ClassifiedResult> {
+  try {
+    const client = assertSupabase();
+    const contactEmail = optionalText(input.contactEmail);
+    const contactPhone = optionalText(input.contactPhone);
+
+    if (!contactEmail && !contactPhone) {
+      return { success: false, error: 'Add an email or phone number so people can contact you.' };
+    }
+
+    const { data, error } = await client
+      .from('classifieds')
+      .insert({
+        kind: input.kind,
+        status: 'pending',
+        title: input.title.trim(),
+        description: input.description.trim(),
+        city_id: input.cityId,
+        category_id: optionalText(input.categoryId),
+        duration_type: input.durationType,
+        organization_name: optionalText(input.organizationName),
+        compensation_label: optionalText(input.compensationLabel),
+        start_date: optionalText(input.startDate),
+        end_date: optionalText(input.endDate),
+        contact_name: input.contactName.trim(),
+        contact_email: contactEmail,
+        contact_phone: contactPhone,
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, id: data?.id };
+  } catch (error) {
+    console.error('Classified submission failed:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unable to submit the listing right now.',
+    };
+  }
+}
+
+export async function fetchApprovedClassifieds() {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('classifieds')
+    .select('*')
+    .eq('status', 'approved')
+    .gt('expires_at', new Date().toISOString())
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as Classified[];
+}
+
+export async function fetchAdminClassifieds() {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('classifieds')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as Classified[];
+}
+
+export async function reviewClassified(
+  classifiedId: string,
+  status: Exclude<ClassifiedStatus, 'pending'>,
+  rejectionReason?: string,
+) {
+  const client = assertSupabase();
+  const { error } = await client.rpc('review_classified', {
+    p_classified_id: classifiedId,
+    p_status: status,
+    p_rejection_reason: optionalText(rejectionReason),
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/lib/classifieds.ts
+++ b/src/lib/classifieds.ts
@@ -113,6 +113,7 @@ export async function fetchApprovedClassifieds() {
   const { data, error } = await client
     .from('classifieds')
     .select('*')
+    .eq('kind', 'job')
     .eq('status', 'approved')
     .gt('expires_at', new Date().toISOString())
     .order('created_at', { ascending: false });

--- a/src/lib/resumeParsing.ts
+++ b/src/lib/resumeParsing.ts
@@ -1,0 +1,220 @@
+import { isSupabaseConfigured, supabase } from '@/src/lib/supabase';
+import type { WorkerAvailability } from '@/src/lib/workerProfiles';
+
+export interface ParsedResumeDraft {
+  display_name: string | null;
+  headline: string | null;
+  category_id: string | null;
+  city_id: string | null;
+  skills: string[];
+  years_experience: number | null;
+  bio: string | null;
+  service_areas: string[];
+  rate_label: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+}
+
+// The full onboarding draft = parsed fields + the fixed-wizard answers.
+export interface OnboardingDraft extends ParsedResumeDraft {
+  availability: WorkerAvailability;
+  open_to_work: boolean;
+  resume_file_name: string | null;
+}
+
+interface AllowedRef {
+  id: string;
+  name: string;
+}
+
+const DRAFT_STORAGE_KEY = 'worker-onboarding:draft';
+const RESUME_DB_NAME = 'worker-onboarding';
+const RESUME_STORE = 'resume';
+const RESUME_KEY = 'pending-resume';
+
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+function emptyDraft(): ParsedResumeDraft {
+  return {
+    display_name: null,
+    headline: null,
+    category_id: null,
+    city_id: null,
+    skills: [],
+    years_experience: null,
+    bio: null,
+    service_areas: [],
+    rate_label: null,
+    contact_email: null,
+    contact_phone: null,
+  };
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // strip the "data:<mime>;base64," prefix
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Could not read the file.'));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function extractDocxText(file: File): Promise<string> {
+  // mammoth ships a browser build; import dynamically so it isn't in the main bundle.
+  const mammoth = await import('mammoth/mammoth.browser');
+  const arrayBuffer = await file.arrayBuffer();
+  const result = await mammoth.extractRawText({ arrayBuffer });
+  return result.value ?? '';
+}
+
+/**
+ * Parse a resume into a structured draft via the `parse_resume` edge function.
+ * PDFs are sent to Gemini natively; DOCX is converted to text client-side; pasted
+ * text is sent as-is. On any failure an empty draft is returned so onboarding can
+ * always continue with manual entry.
+ */
+export async function parseResume(
+  input: { file?: File; text?: string },
+  categories: AllowedRef[],
+  cities: AllowedRef[],
+): Promise<{ draft: ParsedResumeDraft; error?: string }> {
+  if (!isSupabaseConfigured() || !supabase) {
+    return { draft: emptyDraft(), error: 'Resume parsing is not configured in this environment.' };
+  }
+
+  const body: Record<string, unknown> = {
+    categories: categories.map((c) => ({ id: c.id, name: c.name })),
+    cities: cities.map((c) => ({ id: c.id, name: c.name })),
+  };
+
+  try {
+    if (input.file) {
+      const file = input.file;
+      const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+      const isDocx = file.type === DOCX_MIME || file.name.toLowerCase().endsWith('.docx');
+
+      if (isPdf) {
+        body.fileBase64 = await fileToBase64(file);
+        body.mimeType = 'application/pdf';
+      } else if (isDocx) {
+        const text = (await extractDocxText(file)).trim();
+        if (!text) {
+          return { draft: emptyDraft(), error: 'That document looked empty. Try pasting your resume text.' };
+        }
+        body.text = text;
+      } else {
+        return { draft: emptyDraft(), error: 'Unsupported file type. Upload a PDF or DOCX, or paste your resume.' };
+      }
+    } else if (input.text && input.text.trim()) {
+      body.text = input.text.trim();
+    } else {
+      return { draft: emptyDraft(), error: 'Add a resume file or paste some text first.' };
+    }
+
+    const { data, error } = await supabase.functions.invoke('parse_resume', { body });
+
+    if (error) {
+      return { draft: emptyDraft(), error: 'We could not read that resume. You can fill the form manually.' };
+    }
+    if (!data?.success || !data?.draft) {
+      return { draft: emptyDraft(), error: data?.error ?? 'We could not read that resume. You can fill the form manually.' };
+    }
+
+    return { draft: { ...emptyDraft(), ...(data.draft as ParsedResumeDraft) } };
+  } catch (caughtError) {
+    return {
+      draft: emptyDraft(),
+      error: caughtError instanceof Error ? caughtError.message : 'Something went wrong reading the resume.',
+    };
+  }
+}
+
+// ---- Draft persistence across the sign-in redirect ----
+
+export function saveOnboardingDraft(draft: OnboardingDraft) {
+  try {
+    window.sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+  } catch {
+    // sessionStorage may be unavailable (private mode); onboarding still works in-session.
+  }
+}
+
+export function loadOnboardingDraft(): OnboardingDraft | null {
+  try {
+    const raw = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as OnboardingDraft) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearOnboardingDraft() {
+  try {
+    window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+// ---- Raw resume blob persistence (IndexedDB survives the OAuth redirect) ----
+
+function openResumeDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(RESUME_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(RESUME_STORE);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB unavailable.'));
+  });
+}
+
+export async function saveResumeBlob(file: File): Promise<void> {
+  try {
+    const db = await openResumeDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(RESUME_STORE, 'readwrite');
+      tx.objectStore(RESUME_STORE).put(file, RESUME_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch {
+    // Best-effort: if we can't stash the file, publish proceeds without the raw resume.
+  }
+}
+
+export async function loadResumeBlob(): Promise<File | null> {
+  try {
+    const db = await openResumeDb();
+    const file = await new Promise<File | null>((resolve, reject) => {
+      const tx = db.transaction(RESUME_STORE, 'readonly');
+      const getReq = tx.objectStore(RESUME_STORE).get(RESUME_KEY);
+      getReq.onsuccess = () => resolve((getReq.result as File) ?? null);
+      getReq.onerror = () => reject(getReq.error);
+    });
+    db.close();
+    return file;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearResumeBlob(): Promise<void> {
+  try {
+    const db = await openResumeDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(RESUME_STORE, 'readwrite');
+      tx.objectStore(RESUME_STORE).delete(RESUME_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+  } catch {
+    // ignore
+  }
+}

--- a/src/lib/resumeParsing.ts
+++ b/src/lib/resumeParsing.ts
@@ -33,6 +33,9 @@ const RESUME_STORE = 'resume';
 const RESUME_KEY = 'pending-resume';
 
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+// Guard before reading the file into memory / base64 (keeps the edge function's
+// ~6MB binary cap in sync and avoids freezing the browser on huge files).
+const MAX_RESUME_BYTES = 6 * 1024 * 1024;
 
 function emptyDraft(): ParsedResumeDraft {
   return {
@@ -94,6 +97,9 @@ export async function parseResume(
   try {
     if (input.file) {
       const file = input.file;
+      if (file.size > MAX_RESUME_BYTES) {
+        return { draft: emptyDraft(), error: 'That file is too large (max 6MB). Try a smaller PDF or paste your resume text.' };
+      }
       const isPdf = file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
       const isDocx = file.type === DOCX_MIME || file.name.toLowerCase().endsWith('.docx');
 
@@ -126,26 +132,30 @@ export async function parseResume(
 
     return { draft: { ...emptyDraft(), ...(data.draft as ParsedResumeDraft) } };
   } catch (caughtError) {
+    // Don't surface raw parser/exception text to users; log for debugging only.
+    console.error('Resume parse failed:', caughtError);
     return {
       draft: emptyDraft(),
-      error: caughtError instanceof Error ? caughtError.message : 'Something went wrong reading the resume.',
+      error: 'We could not read that resume. You can fill the form manually.',
     };
   }
 }
 
 // ---- Draft persistence across the sign-in redirect ----
 
+// Uses localStorage (not sessionStorage): a magic-link sign-in opens a NEW tab,
+// where sessionStorage would be empty and the draft lost.
 export function saveOnboardingDraft(draft: OnboardingDraft) {
   try {
-    window.sessionStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+    window.localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
   } catch {
-    // sessionStorage may be unavailable (private mode); onboarding still works in-session.
+    // localStorage may be unavailable (private mode); onboarding still works in-session.
   }
 }
 
 export function loadOnboardingDraft(): OnboardingDraft | null {
   try {
-    const raw = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+    const raw = window.localStorage.getItem(DRAFT_STORAGE_KEY);
     return raw ? (JSON.parse(raw) as OnboardingDraft) : null;
   } catch {
     return null;
@@ -154,7 +164,7 @@ export function loadOnboardingDraft(): OnboardingDraft | null {
 
 export function clearOnboardingDraft() {
   try {
-    window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
+    window.localStorage.removeItem(DRAFT_STORAGE_KEY);
   } catch {
     // ignore
   }

--- a/src/lib/workerProfiles.ts
+++ b/src/lib/workerProfiles.ts
@@ -158,7 +158,7 @@ export async function upsertWorkerProfile(userId: string, input: WorkerProfileIn
         years_experience:
           input.yearsExperience === undefined || input.yearsExperience === null || !Number.isFinite(input.yearsExperience)
             ? null
-            : Math.max(0, Math.round(input.yearsExperience)),
+            : Math.min(70, Math.max(0, Math.round(input.yearsExperience))),
         bio: input.bio.trim(),
         photo_url: optionalText(input.photoUrl),
         resume_path: optionalText(input.resumePath),

--- a/src/lib/workerProfiles.ts
+++ b/src/lib/workerProfiles.ts
@@ -62,6 +62,31 @@ function assertSupabase() {
   return supabase;
 }
 
+// crypto.randomUUID is only defined in secure contexts (HTTPS/localhost). Fall
+// back so uploads don't crash when testing over plain HTTP on a LAN/mobile IP.
+function safeUuid() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+function assertUploadable(file: File, allowedMimes: string[], maxBytes: number, label: string) {
+  if (file.size > maxBytes) {
+    throw new Error(`${label} must be under ${Math.round(maxBytes / (1024 * 1024))}MB.`);
+  }
+  // Some browsers leave file.type empty; allow when unknown, otherwise enforce.
+  if (file.type && !allowedMimes.includes(file.type)) {
+    throw new Error(`Unsupported ${label.toLowerCase()} format.`);
+  }
+}
+
+const PHOTO_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+const RESUME_MIMES = [
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+];
+
 export async function fetchApprovedWorkerProfiles() {
   const client = assertSupabase();
   const { data, error } = await client
@@ -131,9 +156,9 @@ export async function upsertWorkerProfile(userId: string, input: WorkerProfileIn
         skills: input.skills ?? [],
         rate_label: optionalText(input.rateLabel),
         years_experience:
-          input.yearsExperience === undefined || input.yearsExperience === null || Number.isNaN(input.yearsExperience)
+          input.yearsExperience === undefined || input.yearsExperience === null || !Number.isFinite(input.yearsExperience)
             ? null
-            : input.yearsExperience,
+            : Math.max(0, Math.round(input.yearsExperience)),
         bio: input.bio.trim(),
         photo_url: optionalText(input.photoUrl),
         resume_path: optionalText(input.resumePath),
@@ -156,8 +181,9 @@ export async function upsertWorkerProfile(userId: string, input: WorkerProfileIn
 
 export async function uploadWorkerPhoto(userId: string, file: File) {
   const client = assertSupabase();
+  assertUploadable(file, PHOTO_MIMES, 5 * 1024 * 1024, 'Photo');
   const extension = file.name.split('.').pop()?.toLowerCase() || 'jpg';
-  const filePath = `${userId}/${crypto.randomUUID()}.${extension}`;
+  const filePath = `${userId}/${safeUuid()}.${extension}`;
 
   const { error: uploadError } = await client.storage
     .from('worker-photos')
@@ -178,8 +204,9 @@ export async function uploadWorkerPhoto(userId: string, file: File) {
 // PATH (not a public URL — the bucket is private; admins read via signed URLs).
 export async function uploadResume(userId: string, file: File) {
   const client = assertSupabase();
+  assertUploadable(file, RESUME_MIMES, 10 * 1024 * 1024, 'Resume');
   const extension = file.name.split('.').pop()?.toLowerCase() || 'pdf';
-  const filePath = `${userId}/${crypto.randomUUID()}.${extension}`;
+  const filePath = `${userId}/${safeUuid()}.${extension}`;
 
   const { error: uploadError } = await client.storage
     .from('resumes')

--- a/src/lib/workerProfiles.ts
+++ b/src/lib/workerProfiles.ts
@@ -1,0 +1,236 @@
+import { isSupabaseConfigured, supabase } from '@/src/lib/supabase';
+
+export type WorkerProfileStatus = 'pending' | 'approved' | 'rejected' | 'archived';
+export type WorkerAvailability = 'on_demand' | 'short_term' | 'full_time';
+
+export interface WorkerProfile {
+  id: string;
+  user_id: string;
+  status: WorkerProfileStatus;
+  display_name: string;
+  headline: string;
+  city_id: string;
+  category_id: string | null;
+  availability: WorkerAvailability;
+  service_areas: string[];
+  skills: string[];
+  rate_label: string | null;
+  years_experience: number | null;
+  bio: string;
+  photo_url: string | null;
+  resume_path: string | null;
+  open_to_work: boolean;
+  contact_name: string;
+  contact_email: string | null;
+  contact_phone: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  rejection_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkerProfileInput {
+  displayName: string;
+  headline: string;
+  cityId: string;
+  categoryId?: string;
+  availability: WorkerAvailability;
+  serviceAreas?: string[];
+  skills?: string[];
+  rateLabel?: string;
+  yearsExperience?: number | null;
+  bio: string;
+  photoUrl?: string | null;
+  resumePath?: string | null;
+  openToWork?: boolean;
+  contactName: string;
+  contactEmail?: string;
+  contactPhone?: string;
+}
+
+function optionalText(value?: string | null) {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function assertSupabase() {
+  if (!isSupabaseConfigured() || !supabase) {
+    throw new Error('Worker profiles require a configured Supabase environment.');
+  }
+
+  return supabase;
+}
+
+export async function fetchApprovedWorkerProfiles() {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('worker_profiles')
+    .select('*')
+    .eq('status', 'approved')
+    .eq('open_to_work', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as WorkerProfile[];
+}
+
+export async function fetchWorkerProfileById(id: string) {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('worker_profiles')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? null) as WorkerProfile | null;
+}
+
+export async function fetchMyWorkerProfile(userId: string) {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('worker_profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? null) as WorkerProfile | null;
+}
+
+export async function upsertWorkerProfile(userId: string, input: WorkerProfileInput) {
+  const client = assertSupabase();
+  const contactEmail = optionalText(input.contactEmail);
+  const contactPhone = optionalText(input.contactPhone);
+
+  if (!contactEmail && !contactPhone) {
+    throw new Error('Add an email or phone number so people can contact you.');
+  }
+
+  const { data, error } = await client
+    .from('worker_profiles')
+    .upsert(
+      {
+        user_id: userId,
+        display_name: input.displayName.trim(),
+        headline: input.headline.trim(),
+        city_id: input.cityId,
+        category_id: optionalText(input.categoryId),
+        availability: input.availability,
+        service_areas: input.serviceAreas ?? [],
+        skills: input.skills ?? [],
+        rate_label: optionalText(input.rateLabel),
+        years_experience:
+          input.yearsExperience === undefined || input.yearsExperience === null || Number.isNaN(input.yearsExperience)
+            ? null
+            : input.yearsExperience,
+        bio: input.bio.trim(),
+        photo_url: optionalText(input.photoUrl),
+        resume_path: optionalText(input.resumePath),
+        open_to_work: input.openToWork ?? true,
+        contact_name: input.contactName.trim(),
+        contact_email: contactEmail,
+        contact_phone: contactPhone,
+      },
+      { onConflict: 'user_id' },
+    )
+    .select('*')
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data as WorkerProfile;
+}
+
+export async function uploadWorkerPhoto(userId: string, file: File) {
+  const client = assertSupabase();
+  const extension = file.name.split('.').pop()?.toLowerCase() || 'jpg';
+  const filePath = `${userId}/${crypto.randomUUID()}.${extension}`;
+
+  const { error: uploadError } = await client.storage
+    .from('worker-photos')
+    .upload(filePath, file, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message);
+  }
+
+  const { data } = client.storage.from('worker-photos').getPublicUrl(filePath);
+  return data.publicUrl;
+}
+
+// Uploads a raw resume to the private `resumes` bucket and returns the storage
+// PATH (not a public URL — the bucket is private; admins read via signed URLs).
+export async function uploadResume(userId: string, file: File) {
+  const client = assertSupabase();
+  const extension = file.name.split('.').pop()?.toLowerCase() || 'pdf';
+  const filePath = `${userId}/${crypto.randomUUID()}.${extension}`;
+
+  const { error: uploadError } = await client.storage
+    .from('resumes')
+    .upload(filePath, file, {
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message);
+  }
+
+  return filePath;
+}
+
+export async function createResumeSignedUrl(path: string, expiresInSeconds = 60) {
+  const client = assertSupabase();
+  const { data, error } = await client.storage.from('resumes').createSignedUrl(path, expiresInSeconds);
+  if (error) {
+    throw new Error(error.message);
+  }
+  return data.signedUrl;
+}
+
+export async function fetchAdminWorkerProfiles() {
+  const client = assertSupabase();
+  const { data, error } = await client
+    .from('worker_profiles')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data ?? []) as WorkerProfile[];
+}
+
+export async function reviewWorkerProfile(
+  profileId: string,
+  status: Exclude<WorkerProfileStatus, 'pending'>,
+  rejectionReason?: string,
+) {
+  const client = assertSupabase();
+  const { error } = await client.rpc('review_worker_profile', {
+    p_profile_id: profileId,
+    p_status: status,
+    p_rejection_reason: optionalText(rejectionReason),
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}

--- a/src/pages/AdminClassifiedsPage.tsx
+++ b/src/pages/AdminClassifiedsPage.tsx
@@ -285,10 +285,10 @@ export default function AdminClassifiedsPage() {
         <section className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
             <div>
-              <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search classifieds</label>
+              <label htmlFor="admin-classifieds-search" className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search classifieds</label>
               <div className="relative mt-3">
                 <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
-                <input type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Title, contact, city, trade, notes" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
+                <input id="admin-classifieds-search" type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Title, contact, city, trade, notes" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
               </div>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/src/pages/AdminClassifiedsPage.tsx
+++ b/src/pages/AdminClassifiedsPage.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  Archive,
+  BriefcaseBusiness,
+  CheckCircle2,
+  Clock3,
+  Mail,
+  MapPin,
+  Phone,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  UserRound,
+  XCircle,
+} from 'lucide-react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type Classified,
+  type ClassifiedStatus,
+  fetchAdminClassifieds,
+  reviewClassified,
+} from '@/src/lib/classifieds';
+
+type StatusFilter = 'all' | ClassifiedStatus;
+
+const statusFilters: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'all', label: 'All listings' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'archived', label: 'Archived' },
+];
+
+function formatDateTime(value: string | null) {
+  if (!value) return 'Not recorded';
+  return new Date(value).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function durationLabel(value: Classified['duration_type']) {
+  if (value === 'on_demand') return 'On-demand';
+  if (value === 'short_term') return 'Short-term';
+  return 'Full-time';
+}
+
+function statusStyles(status: ClassifiedStatus) {
+  if (status === 'approved') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  if (status === 'rejected') return 'border-rose-200 bg-rose-50 text-rose-800';
+  if (status === 'archived') return 'border-zinc-200 bg-zinc-100 text-zinc-600';
+  return 'border-amber-200 bg-amber-50 text-amber-800';
+}
+
+interface AdminListingCardProps {
+  listing: Classified;
+  cityName: string;
+  categoryName: string;
+  reason: string;
+  error?: string;
+  processing: boolean;
+  onReasonChange: (value: string) => void;
+  onReview: (status: Exclude<ClassifiedStatus, 'pending'>) => void;
+}
+
+function AdminListingCard({
+  listing,
+  cityName,
+  categoryName,
+  reason,
+  error,
+  processing,
+  onReasonChange,
+  onReview,
+}: AdminListingCardProps) {
+  return (
+    <article className="border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap gap-2">
+            <span className={`inline-flex items-center gap-2 border px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] ${statusStyles(listing.status)}`}>
+              {listing.status === 'pending' ? <Clock3 className="h-3.5 w-3.5" /> : null}
+              {listing.status === 'approved' ? <CheckCircle2 className="h-3.5 w-3.5" /> : null}
+              {listing.status === 'rejected' ? <XCircle className="h-3.5 w-3.5" /> : null}
+              {listing.status === 'archived' ? <Archive className="h-3.5 w-3.5" /> : null}
+              {listing.status}
+            </span>
+            <span className="inline-flex items-center gap-2 border border-zinc-200 bg-zinc-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-600">
+              {listing.kind === 'job' ? <BriefcaseBusiness className="h-3.5 w-3.5" /> : <UserRound className="h-3.5 w-3.5" />}
+              {listing.kind === 'job' ? 'Job' : 'Labourer'}
+            </span>
+          </div>
+          <h3 className="mt-4 text-xl font-bold text-zinc-950">{listing.title}</h3>
+          <p className="mt-1 text-sm text-zinc-500">Submitted {formatDateTime(listing.created_at)} - Expires {formatDateTime(listing.expires_at)}</p>
+        </div>
+        <div className="text-sm text-zinc-600 lg:text-right">
+          <p className="font-semibold text-zinc-950">{listing.contact_name}</p>
+          {listing.contact_phone ? <p className="mt-1 inline-flex items-center gap-1 lg:justify-end"><Phone className="h-3.5 w-3.5" />{listing.contact_phone}</p> : null}
+          {listing.contact_email ? <p className="mt-1 inline-flex items-center gap-1 lg:justify-end"><Mail className="h-3.5 w-3.5" />{listing.contact_email}</p> : null}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 text-sm text-zinc-600 md:grid-cols-2 xl:grid-cols-4">
+        <p className="flex items-center gap-2"><MapPin className="h-4 w-4 text-zinc-400" />{cityName}</p>
+        <p>{categoryName}</p>
+        <p>{durationLabel(listing.duration_type)}</p>
+        <p>{listing.compensation_label ?? 'Rate not posted'}</p>
+      </div>
+
+      {listing.organization_name ? <p className="mt-3 text-sm font-semibold text-zinc-700">{listing.organization_name}</p> : null}
+      <p className="mt-3 whitespace-pre-line border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm leading-6 text-zinc-700">{listing.description}</p>
+
+      {listing.rejection_reason ? (
+        <p className="mt-3 border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{listing.rejection_reason}</p>
+      ) : null}
+
+      {listing.status !== 'archived' ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
+          <textarea
+            value={reason}
+            onChange={(event) => onReasonChange(event.target.value)}
+            rows={3}
+            placeholder="Rejection reason (required if rejecting)"
+            className="w-full resize-none border border-zinc-200 bg-white px-3 py-3 text-sm text-zinc-900 outline-none focus:border-zinc-900"
+          />
+          {listing.status === 'pending' ? (
+            <button
+              type="button"
+              onClick={() => onReview('approved')}
+              disabled={processing}
+              className="inline-flex items-center justify-center gap-2 border border-emerald-500 bg-emerald-500 px-4 py-3 text-xs font-bold uppercase tracking-wide text-white disabled:opacity-60"
+            >
+              <CheckCircle2 className="h-4 w-4" />Approve
+            </button>
+          ) : null}
+          {listing.status === 'pending' ? (
+            <button
+              type="button"
+              onClick={() => onReview('rejected')}
+              disabled={processing}
+              className="inline-flex items-center justify-center gap-2 border border-rose-200 bg-white px-4 py-3 text-xs font-bold uppercase tracking-wide text-rose-700 disabled:opacity-60"
+            >
+              <XCircle className="h-4 w-4" />Reject
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onReview('archived')}
+            disabled={processing}
+            className="inline-flex items-center justify-center gap-2 border border-zinc-200 bg-zinc-50 px-4 py-3 text-xs font-bold uppercase tracking-wide text-zinc-700 disabled:opacity-60"
+          >
+            <Archive className="h-4 w-4" />Archive
+          </button>
+        </div>
+      ) : null}
+      {error ? <p className="mt-2 text-sm text-rose-600">{error}</p> : null}
+    </article>
+  );
+}
+
+export default function AdminClassifiedsPage() {
+  const { cities, categories } = useDirectoryData();
+  const [listings, setListings] = useState<Classified[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [rejectionReason, setRejectionReason] = useState<Record<string, string>>({});
+  const [listingErrors, setListingErrors] = useState<Record<string, string>>({});
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const cityNames = useMemo(() => new Map(cities.map((city) => [city.id, city.name])), [cities]);
+  const categoryNames = useMemo(() => new Map(categories.map((category) => [category.id, category.name])), [categories]);
+
+  async function loadListings(options?: { silent?: boolean }) {
+    const silent = options?.silent ?? false;
+    if (silent) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchAdminClassifieds();
+      setListings(data);
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to load classifieds.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadListings();
+  }, []);
+
+  const summary = useMemo(() => listings.reduce((counts, listing) => {
+    counts.total += 1;
+    counts[listing.status] += 1;
+    return counts;
+  }, { total: 0, pending: 0, approved: 0, rejected: 0, archived: 0 }), [listings]);
+
+  const filteredListings = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return listings
+      .filter((listing) => statusFilter === 'all' || listing.status === statusFilter)
+      .filter((listing) => {
+        if (!query) return true;
+        return [
+          listing.title,
+          listing.description,
+          listing.contact_name,
+          listing.contact_email ?? '',
+          listing.contact_phone ?? '',
+          listing.organization_name ?? '',
+          listing.rejection_reason ?? '',
+          cityNames.get(listing.city_id) ?? listing.city_id,
+          listing.category_id ? categoryNames.get(listing.category_id) ?? listing.category_id : '',
+        ].some((value) => value.toLowerCase().includes(query));
+      });
+  }, [categoryNames, cityNames, listings, searchQuery, statusFilter]);
+
+  const pendingListings = useMemo(() => filteredListings.filter((listing) => listing.status === 'pending'), [filteredListings]);
+  const reviewedListings = useMemo(() => filteredListings.filter((listing) => listing.status !== 'pending'), [filteredListings]);
+
+  async function handleReview(classifiedId: string, status: Exclude<ClassifiedStatus, 'pending'>) {
+    if (processingId) return;
+    const reason = rejectionReason[classifiedId]?.trim() ?? '';
+
+    if (status === 'rejected' && !reason) {
+      setListingErrors((current) => ({ ...current, [classifiedId]: 'Please provide a rejection reason.' }));
+      return;
+    }
+
+    setProcessingId(classifiedId);
+    setListingErrors((current) => ({ ...current, [classifiedId]: '' }));
+    setError(null);
+
+    try {
+      await reviewClassified(classifiedId, status, reason);
+      setRejectionReason((current) => ({ ...current, [classifiedId]: '' }));
+      await loadListings({ silent: true });
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to update the listing.');
+    } finally {
+      setProcessingId(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA]"><div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div></div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900">
+      <Seo title="Admin Classifieds | Okanagan Trades" description="Review and moderate Okanagan Trades classifieds." path="/admin/classifieds" robots="noindex,nofollow" />
+      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-10">
+        <div className="flex flex-col gap-6 border-b border-zinc-200 pb-10 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <SectionEyebrow icon={ShieldCheck} className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm" iconClassName="h-3.5 w-3.5 text-orange-500">Admin Operations</SectionEyebrow>
+            <h1 className="mt-6 text-4xl font-bold uppercase text-zinc-950 sm:text-5xl lg:text-6xl">Classifieds admin</h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-zinc-600">Review pending public submissions, approve listings, reject with a reason, or archive older posts.</p>
+          </div>
+          <button type="button" onClick={() => void loadListings({ silent: true })} disabled={refreshing || Boolean(processingId)} className="inline-flex items-center justify-center gap-3 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950 disabled:opacity-60">
+            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />{refreshing ? 'Refreshing' : 'Refresh queue'}
+          </button>
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          {[
+            { label: 'Total', value: summary.total },
+            { label: 'Pending', value: summary.pending },
+            { label: 'Approved', value: summary.approved },
+            { label: 'Rejected', value: summary.rejected },
+            { label: 'Archived', value: summary.archived },
+          ].map((item) => (
+            <div key={item.label} className="border border-zinc-200 bg-white px-5 py-5 shadow-sm">
+              <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">{item.label}</p>
+              <p className="mt-3 text-4xl font-bold text-zinc-950">{item.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <section className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div>
+              <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search classifieds</label>
+              <div className="relative mt-3">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+                <input type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Title, contact, city, trade, notes" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {statusFilters.map((filter) => (
+                <button key={filter.value} type="button" onClick={() => setStatusFilter(filter.value)} className={`inline-flex items-center gap-2 border px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.18em] transition-colors ${statusFilter === filter.value ? 'border-zinc-900 bg-zinc-900 text-white' : 'border-zinc-200 bg-zinc-50 text-zinc-600 hover:border-zinc-900 hover:bg-white hover:text-zinc-950'}`}>
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {error ? (
+          <div className="mt-8 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        <section className="mt-8">
+          <h2 className="text-2xl font-bold text-zinc-950">{pendingListings.length} pending listings</h2>
+          {pendingListings.length === 0 ? (
+            <div className="mt-4 border border-zinc-200 bg-white px-6 py-10 text-sm text-zinc-500 shadow-sm">No pending classifieds in the current filter.</div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              {pendingListings.map((listing) => (
+                <div key={listing.id}>
+                  <AdminListingCard
+                    listing={listing}
+                    cityName={cityNames.get(listing.city_id) ?? listing.city_id}
+                    categoryName={listing.category_id ? categoryNames.get(listing.category_id) ?? listing.category_id : 'General labour'}
+                    reason={rejectionReason[listing.id] ?? ''}
+                    error={listingErrors[listing.id]}
+                    processing={processingId === listing.id}
+                    onReasonChange={(value) => setRejectionReason((current) => ({ ...current, [listing.id]: value }))}
+                    onReview={(status) => void handleReview(listing.id, status)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-10">
+          <h2 className="text-2xl font-bold text-zinc-950">{reviewedListings.length} reviewed listings</h2>
+          {reviewedListings.length === 0 ? (
+            <div className="mt-4 border border-zinc-200 bg-white px-6 py-10 text-sm text-zinc-500 shadow-sm">No reviewed classifieds in the current filter.</div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              {reviewedListings.map((listing) => (
+                <div key={listing.id}>
+                  <AdminListingCard
+                    listing={listing}
+                    cityName={cityNames.get(listing.city_id) ?? listing.city_id}
+                    categoryName={listing.category_id ? categoryNames.get(listing.category_id) ?? listing.category_id : 'General labour'}
+                    reason={rejectionReason[listing.id] ?? ''}
+                    error={listingErrors[listing.id]}
+                    processing={processingId === listing.id}
+                    onReasonChange={(value) => setRejectionReason((current) => ({ ...current, [listing.id]: value }))}
+                    onReview={(status) => void handleReview(listing.id, status)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdminWorkerProfilesPage.tsx
+++ b/src/pages/AdminWorkerProfilesPage.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  AlertCircle,
+  Archive,
+  CheckCircle2,
+  Clock3,
+  FileText,
+  Mail,
+  MapPin,
+  Phone,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  XCircle,
+} from 'lucide-react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { availabilityLabel } from '@/src/components/WorkerCard';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type WorkerProfile,
+  type WorkerProfileStatus,
+  createResumeSignedUrl,
+  fetchAdminWorkerProfiles,
+  reviewWorkerProfile,
+} from '@/src/lib/workerProfiles';
+
+type StatusFilter = 'all' | WorkerProfileStatus;
+
+const statusFilters: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'all', label: 'All profiles' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'archived', label: 'Archived' },
+];
+
+function formatDateTime(value: string | null) {
+  if (!value) return 'Not recorded';
+  return new Date(value).toLocaleString(undefined, { month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function statusStyles(status: WorkerProfileStatus) {
+  if (status === 'approved') return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  if (status === 'rejected') return 'border-rose-200 bg-rose-50 text-rose-800';
+  if (status === 'archived') return 'border-zinc-200 bg-zinc-100 text-zinc-600';
+  return 'border-amber-200 bg-amber-50 text-amber-800';
+}
+
+interface AdminWorkerCardProps {
+  worker: WorkerProfile;
+  cityName: string;
+  categoryName: string;
+  reason: string;
+  error?: string;
+  processing: boolean;
+  onReasonChange: (value: string) => void;
+  onReview: (status: Exclude<WorkerProfileStatus, 'pending'>) => void;
+}
+
+function AdminWorkerCard({
+  worker,
+  cityName,
+  categoryName,
+  reason,
+  error,
+  processing,
+  onReasonChange,
+  onReview,
+}: AdminWorkerCardProps) {
+  return (
+    <article className="border border-zinc-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 gap-4">
+          <div className="h-16 w-16 shrink-0 overflow-hidden border border-zinc-200 bg-zinc-100">
+            {worker.photo_url ? (
+              <img src={worker.photo_url} alt={worker.display_name} className="h-full w-full object-cover" />
+            ) : null}
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap gap-2">
+              <span className={`inline-flex items-center gap-2 border px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] ${statusStyles(worker.status)}`}>
+                {worker.status === 'pending' ? <Clock3 className="h-3.5 w-3.5" /> : null}
+                {worker.status === 'approved' ? <CheckCircle2 className="h-3.5 w-3.5" /> : null}
+                {worker.status === 'rejected' ? <XCircle className="h-3.5 w-3.5" /> : null}
+                {worker.status === 'archived' ? <Archive className="h-3.5 w-3.5" /> : null}
+                {worker.status}
+              </span>
+              <span className="inline-flex items-center border border-orange-200 bg-orange-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-orange-700">
+                {availabilityLabel(worker.availability)}
+              </span>
+            </div>
+            <h3 className="mt-3 text-xl font-bold text-zinc-950">{worker.display_name}</h3>
+            <p className="text-sm font-semibold text-zinc-600">{worker.headline}</p>
+            <p className="mt-1 text-sm text-zinc-500">Submitted {formatDateTime(worker.created_at)}</p>
+          </div>
+        </div>
+        <div className="text-sm text-zinc-600 lg:text-right">
+          <p className="font-semibold text-zinc-950">{worker.contact_name}</p>
+          {worker.contact_phone ? <p className="mt-1 inline-flex items-center gap-1 lg:justify-end"><Phone className="h-3.5 w-3.5" />{worker.contact_phone}</p> : null}
+          {worker.contact_email ? <p className="mt-1 inline-flex items-center gap-1 lg:justify-end"><Mail className="h-3.5 w-3.5" />{worker.contact_email}</p> : null}
+          {worker.resume_path ? (
+            <button
+              type="button"
+              onClick={async () => {
+                try {
+                  const url = await createResumeSignedUrl(worker.resume_path as string, 120);
+                  window.open(url, '_blank', 'noopener,noreferrer');
+                } catch {
+                  /* ignore — signed URL failed */
+                }
+              }}
+              className="mt-2 inline-flex items-center gap-1 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-700 underline underline-offset-4 transition-colors hover:text-orange-600 lg:justify-end"
+            >
+              <FileText className="h-3.5 w-3.5" />
+              View resume
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 text-sm text-zinc-600 md:grid-cols-2 xl:grid-cols-4">
+        <p className="flex items-center gap-2"><MapPin className="h-4 w-4 text-zinc-400" />{cityName}</p>
+        <p>{categoryName}</p>
+        <p>{worker.years_experience !== null ? `${worker.years_experience} yrs experience` : 'Experience not given'}</p>
+        <p>{worker.rate_label ?? 'Rate not posted'}</p>
+      </div>
+
+      {worker.skills.length > 0 ? <p className="mt-3 text-sm text-zinc-600"><span className="font-semibold text-zinc-700">Skills:</span> {worker.skills.join(', ')}</p> : null}
+      {worker.service_areas.length > 0 ? <p className="mt-1 text-sm text-zinc-600"><span className="font-semibold text-zinc-700">Areas:</span> {worker.service_areas.join(', ')}</p> : null}
+      <p className="mt-3 whitespace-pre-line border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm leading-6 text-zinc-700">{worker.bio}</p>
+
+      {worker.rejection_reason ? (
+        <p className="mt-3 border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">{worker.rejection_reason}</p>
+      ) : null}
+
+      {worker.status !== 'archived' ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
+          <textarea
+            value={reason}
+            onChange={(event) => onReasonChange(event.target.value)}
+            rows={3}
+            placeholder="Rejection reason (required if rejecting)"
+            className="w-full resize-none border border-zinc-200 bg-white px-3 py-3 text-sm text-zinc-900 outline-none focus:border-zinc-900"
+          />
+          {worker.status === 'pending' ? (
+            <button type="button" onClick={() => onReview('approved')} disabled={processing} className="inline-flex items-center justify-center gap-2 border border-emerald-500 bg-emerald-500 px-4 py-3 text-xs font-bold uppercase tracking-wide text-white disabled:opacity-60">
+              <CheckCircle2 className="h-4 w-4" />Approve
+            </button>
+          ) : null}
+          {worker.status === 'pending' ? (
+            <button type="button" onClick={() => onReview('rejected')} disabled={processing} className="inline-flex items-center justify-center gap-2 border border-rose-200 bg-white px-4 py-3 text-xs font-bold uppercase tracking-wide text-rose-700 disabled:opacity-60">
+              <XCircle className="h-4 w-4" />Reject
+            </button>
+          ) : null}
+          <button type="button" onClick={() => onReview('archived')} disabled={processing} className="inline-flex items-center justify-center gap-2 border border-zinc-200 bg-zinc-50 px-4 py-3 text-xs font-bold uppercase tracking-wide text-zinc-700 disabled:opacity-60">
+            <Archive className="h-4 w-4" />Archive
+          </button>
+        </div>
+      ) : null}
+      {error ? <p className="mt-2 text-sm text-rose-600">{error}</p> : null}
+    </article>
+  );
+}
+
+export default function AdminWorkerProfilesPage() {
+  const { cities, categories } = useDirectoryData();
+  const [workers, setWorkers] = useState<WorkerProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [rejectionReason, setRejectionReason] = useState<Record<string, string>>({});
+  const [workerErrors, setWorkerErrors] = useState<Record<string, string>>({});
+  const [processingId, setProcessingId] = useState<string | null>(null);
+
+  const cityNames = useMemo(() => new Map(cities.map((city) => [city.id, city.name])), [cities]);
+  const categoryNames = useMemo(() => new Map(categories.map((category) => [category.id, category.name])), [categories]);
+
+  async function loadWorkers(options?: { silent?: boolean }) {
+    const silent = options?.silent ?? false;
+    if (silent) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchAdminWorkerProfiles();
+      setWorkers(data);
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to load worker profiles.');
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadWorkers();
+  }, []);
+
+  const summary = useMemo(() => workers.reduce((counts, worker) => {
+    counts.total += 1;
+    counts[worker.status] += 1;
+    return counts;
+  }, { total: 0, pending: 0, approved: 0, rejected: 0, archived: 0 }), [workers]);
+
+  const filteredWorkers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return workers
+      .filter((worker) => statusFilter === 'all' || worker.status === statusFilter)
+      .filter((worker) => {
+        if (!query) return true;
+        return [
+          worker.display_name,
+          worker.headline,
+          worker.bio,
+          worker.contact_name,
+          worker.contact_email ?? '',
+          worker.contact_phone ?? '',
+          worker.skills.join(' '),
+          worker.rejection_reason ?? '',
+          cityNames.get(worker.city_id) ?? worker.city_id,
+          worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : '',
+        ].some((value) => value.toLowerCase().includes(query));
+      });
+  }, [categoryNames, cityNames, searchQuery, statusFilter, workers]);
+
+  const pendingWorkers = useMemo(() => filteredWorkers.filter((worker) => worker.status === 'pending'), [filteredWorkers]);
+  const reviewedWorkers = useMemo(() => filteredWorkers.filter((worker) => worker.status !== 'pending'), [filteredWorkers]);
+
+  async function handleReview(profileId: string, status: Exclude<WorkerProfileStatus, 'pending'>) {
+    if (processingId) return;
+    const reason = rejectionReason[profileId]?.trim() ?? '';
+
+    if (status === 'rejected' && !reason) {
+      setWorkerErrors((current) => ({ ...current, [profileId]: 'Please provide a rejection reason.' }));
+      return;
+    }
+
+    setProcessingId(profileId);
+    setWorkerErrors((current) => ({ ...current, [profileId]: '' }));
+    setError(null);
+
+    try {
+      await reviewWorkerProfile(profileId, status, reason);
+      setRejectionReason((current) => ({ ...current, [profileId]: '' }));
+      await loadWorkers({ silent: true });
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to update the profile.');
+    } finally {
+      setProcessingId(null);
+    }
+  }
+
+  if (loading) {
+    return <div className="flex min-h-[60vh] items-center justify-center bg-[#FAFAFA]"><div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div></div>;
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900">
+      <Seo title="Admin Worker Profiles | Okanagan Trades" description="Review and moderate Okanagan Trades worker profiles." path="/admin/workers" robots="noindex,nofollow" />
+      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-10">
+        <div className="flex flex-col gap-6 border-b border-zinc-200 pb-10 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <SectionEyebrow icon={ShieldCheck} className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm" iconClassName="h-3.5 w-3.5 text-orange-500">Admin Operations</SectionEyebrow>
+            <h1 className="mt-6 text-4xl font-bold uppercase text-zinc-950 sm:text-5xl lg:text-6xl">Worker profiles admin</h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-zinc-600">Review submitted worker profiles, approve them, reject with a reason, or archive older ones.</p>
+          </div>
+          <button type="button" onClick={() => void loadWorkers({ silent: true })} disabled={refreshing || Boolean(processingId)} className="inline-flex items-center justify-center gap-3 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950 disabled:opacity-60">
+            <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} />{refreshing ? 'Refreshing' : 'Refresh queue'}
+          </button>
+        </div>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+          {[
+            { label: 'Total', value: summary.total },
+            { label: 'Pending', value: summary.pending },
+            { label: 'Approved', value: summary.approved },
+            { label: 'Rejected', value: summary.rejected },
+            { label: 'Archived', value: summary.archived },
+          ].map((item) => (
+            <div key={item.label} className="border border-zinc-200 bg-white px-5 py-5 shadow-sm">
+              <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">{item.label}</p>
+              <p className="mt-3 text-4xl font-bold text-zinc-950">{item.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <section className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div>
+              <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search profiles</label>
+              <div className="relative mt-3">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+                <input type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Name, headline, contact, skills, city, trade" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {statusFilters.map((filter) => (
+                <button key={filter.value} type="button" onClick={() => setStatusFilter(filter.value)} className={`inline-flex items-center gap-2 border px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.18em] transition-colors ${statusFilter === filter.value ? 'border-zinc-900 bg-zinc-900 text-white' : 'border-zinc-200 bg-zinc-50 text-zinc-600 hover:border-zinc-900 hover:bg-white hover:text-zinc-950'}`}>
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {error ? (
+          <div className="mt-8 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        <section className="mt-8">
+          <h2 className="text-2xl font-bold text-zinc-950">{pendingWorkers.length} pending profiles</h2>
+          {pendingWorkers.length === 0 ? (
+            <div className="mt-4 border border-zinc-200 bg-white px-6 py-10 text-sm text-zinc-500 shadow-sm">No pending profiles in the current filter.</div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              {pendingWorkers.map((worker) => (
+                <div key={worker.id}>
+                  <AdminWorkerCard
+                    worker={worker}
+                    cityName={cityNames.get(worker.city_id) ?? worker.city_id}
+                    categoryName={worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : 'General labour'}
+                    reason={rejectionReason[worker.id] ?? ''}
+                    error={workerErrors[worker.id]}
+                    processing={processingId === worker.id}
+                    onReasonChange={(value) => setRejectionReason((current) => ({ ...current, [worker.id]: value }))}
+                    onReview={(status) => void handleReview(worker.id, status)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="mt-10">
+          <h2 className="text-2xl font-bold text-zinc-950">{reviewedWorkers.length} reviewed profiles</h2>
+          {reviewedWorkers.length === 0 ? (
+            <div className="mt-4 border border-zinc-200 bg-white px-6 py-10 text-sm text-zinc-500 shadow-sm">No reviewed profiles in the current filter.</div>
+          ) : (
+            <div className="mt-4 space-y-4">
+              {reviewedWorkers.map((worker) => (
+                <div key={worker.id}>
+                  <AdminWorkerCard
+                    worker={worker}
+                    cityName={cityNames.get(worker.city_id) ?? worker.city_id}
+                    categoryName={worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : 'General labour'}
+                    reason={rejectionReason[worker.id] ?? ''}
+                    error={workerErrors[worker.id]}
+                    processing={processingId === worker.id}
+                    onReasonChange={(value) => setRejectionReason((current) => ({ ...current, [worker.id]: value }))}
+                    onReview={(status) => void handleReview(worker.id, status)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AdminWorkerProfilesPage.tsx
+++ b/src/pages/AdminWorkerProfilesPage.tsx
@@ -291,10 +291,10 @@ export default function AdminWorkerProfilesPage() {
         <section className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
             <div>
-              <label className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search profiles</label>
+              <label htmlFor="admin-workers-search" className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Search profiles</label>
               <div className="relative mt-3">
                 <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
-                <input type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Name, headline, contact, skills, city, trade" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
+                <input id="admin-workers-search" type="text" value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="Name, headline, contact, skills, city, trade" className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white" />
               </div>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/src/pages/AdminWorkerProfilesPage.tsx
+++ b/src/pages/AdminWorkerProfilesPage.tsx
@@ -107,8 +107,8 @@ function AdminWorkerCard({
                 try {
                   const url = await createResumeSignedUrl(worker.resume_path as string, 120);
                   window.open(url, '_blank', 'noopener,noreferrer');
-                } catch {
-                  /* ignore — signed URL failed */
+                } catch (caughtError) {
+                  window.alert(caughtError instanceof Error ? caughtError.message : 'Could not open the resume.');
                 }
               }}
               className="mt-2 inline-flex items-center gap-1 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-700 underline underline-offset-4 transition-colors hover:text-orange-600 lg:justify-end"

--- a/src/pages/ClassifiedsPage.tsx
+++ b/src/pages/ClassifiedsPage.tsx
@@ -56,7 +56,9 @@ function kindLabel(value: Classified['kind']) {
 
 function formatDate(value: string | null) {
   if (!value) return null;
-  return new Date(`${value}T00:00:00`).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
 function dateRangeLabel(listing: Classified) {
@@ -304,10 +306,11 @@ export default function ClassifiedsPage() {
 
           <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_repeat(3,minmax(10rem,14rem))]">
             <div>
-              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Search</label>
+              <label htmlFor="classifieds-search" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Search</label>
               <div className="relative">
                 <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
                 <input
+                  id="classifieds-search"
                   type="search"
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
@@ -317,22 +320,22 @@ export default function ClassifiedsPage() {
               </div>
             </div>
             <div>
-              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City</label>
-              <select value={cityFilter} onChange={(event) => setCityFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+              <label htmlFor="classifieds-city-filter" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City</label>
+              <select id="classifieds-city-filter" value={cityFilter} onChange={(event) => setCityFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
                 <option value="">All cities</option>
                 {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
               </select>
             </div>
             <div>
-              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
-              <select value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+              <label htmlFor="classifieds-category-filter" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+              <select id="classifieds-category-filter" value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
                 <option value="">All trades</option>
                 {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
               </select>
             </div>
             <div>
-              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration</label>
-              <select value={durationFilter} onChange={(event) => setDurationFilter(event.target.value as '' | ClassifiedDurationType)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+              <label htmlFor="classifieds-duration-filter" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration</label>
+              <select id="classifieds-duration-filter" value={durationFilter} onChange={(event) => setDurationFilter(event.target.value as '' | ClassifiedDurationType)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
                 {durationOptions.map((option) => <option key={option.value || 'all'} value={option.value}>{option.label}</option>)}
               </select>
             </div>

--- a/src/pages/ClassifiedsPage.tsx
+++ b/src/pages/ClassifiedsPage.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowRight,
+  BriefcaseBusiness,
+  CalendarDays,
+  Hammer,
+  Mail,
+  MapPin,
+  Phone,
+  Search,
+  UserRound,
+} from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type Classified,
+  type ClassifiedDurationType,
+  fetchApprovedClassifieds,
+} from '@/src/lib/classifieds';
+
+type QuickFilter = 'jobs' | 'on_demand' | 'short_term' | 'full_time';
+
+const quickFilters: Array<{ value: QuickFilter; label: string }> = [
+  { value: 'jobs', label: 'All jobs' },
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+const durationOptions: Array<{ value: '' | ClassifiedDurationType; label: string }> = [
+  { value: '', label: 'Any duration' },
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+const cardVariants = {
+  hidden: { opacity: 0, y: 18 },
+  visible: { opacity: 1, y: 0 },
+};
+
+function durationLabel(value: ClassifiedDurationType) {
+  if (value === 'on_demand') return 'On-demand';
+  if (value === 'short_term') return 'Short-term';
+  return 'Full-time';
+}
+
+function kindLabel(value: Classified['kind']) {
+  return value === 'job' ? 'Hiring' : 'Available for work';
+}
+
+function formatDate(value: string | null) {
+  if (!value) return null;
+  return new Date(`${value}T00:00:00`).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function dateRangeLabel(listing: Classified) {
+  const start = formatDate(listing.start_date);
+  const end = formatDate(listing.end_date);
+
+  if (start && end) return `${start} to ${end}`;
+  if (start) return `Starts ${start}`;
+  if (end) return `Until ${end}`;
+  return null;
+}
+
+interface ClassifiedCardProps {
+  listing: Classified;
+  cityName: string;
+  categoryName: string;
+}
+
+function ClassifiedCard({ listing, cityName, categoryName }: ClassifiedCardProps) {
+  const range = dateRangeLabel(listing);
+
+  return (
+    <motion.article
+      variants={cardVariants}
+      initial="hidden"
+      animate="visible"
+      transition={{ duration: 0.35 }}
+      className="border border-zinc-200 bg-white p-5 shadow-sm"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap gap-2">
+            <span className="inline-flex items-center gap-2 border border-zinc-200 bg-zinc-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-600">
+              {listing.kind === 'job' ? <BriefcaseBusiness className="h-3.5 w-3.5" /> : <UserRound className="h-3.5 w-3.5" />}
+              {kindLabel(listing.kind)}
+            </span>
+            <span className="inline-flex items-center border border-orange-200 bg-orange-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-orange-700">
+              {durationLabel(listing.duration_type)}
+            </span>
+          </div>
+          <h2 className="mt-4 text-2xl font-bold leading-tight text-zinc-950">{listing.title}</h2>
+          {listing.organization_name ? (
+            <p className="mt-2 text-sm font-semibold text-zinc-700">{listing.organization_name}</p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          {listing.contact_phone ? (
+            <a
+              href={`tel:${listing.contact_phone}`}
+              className="inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-900 bg-zinc-900 px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-white transition-colors hover:bg-zinc-800"
+            >
+              <Phone className="h-4 w-4" />
+              Call
+            </a>
+          ) : null}
+          {listing.contact_email ? (
+            <a
+              href={`mailto:${listing.contact_email}`}
+              className="inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-200 bg-white px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950"
+            >
+              <Mail className="h-4 w-4" />
+              Email
+            </a>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 text-sm text-zinc-600 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="flex items-center gap-2">
+          <MapPin className="h-4 w-4 text-zinc-400" />
+          <span>{cityName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Hammer className="h-4 w-4 text-zinc-400" />
+          <span>{categoryName}</span>
+        </div>
+        {listing.compensation_label ? (
+          <div className="font-semibold text-zinc-900">{listing.compensation_label}</div>
+        ) : (
+          <div className="text-zinc-400">Rate not posted</div>
+        )}
+        {range ? (
+          <div className="flex items-center gap-2">
+            <CalendarDays className="h-4 w-4 text-zinc-400" />
+            <span>{range}</span>
+          </div>
+        ) : (
+          <div className="text-zinc-400">Dates flexible</div>
+        )}
+      </div>
+
+      <p className="mt-5 whitespace-pre-line text-base leading-7 text-zinc-700">{listing.description}</p>
+
+      <div className="mt-5 border-t border-zinc-100 pt-4 text-sm text-zinc-500">
+        Contact: <span className="font-semibold text-zinc-800">{listing.contact_name}</span>
+      </div>
+    </motion.article>
+  );
+}
+
+export default function ClassifiedsPage() {
+  const { cities, categories, isLoading: directoryLoading } = useDirectoryData();
+  const [listings, setListings] = useState<Classified[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('jobs');
+  const [cityFilter, setCityFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [durationFilter, setDurationFilter] = useState<'' | ClassifiedDurationType>('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const cityNames = useMemo(() => new Map(cities.map((city) => [city.id, city.name])), [cities]);
+  const categoryNames = useMemo(() => new Map(categories.map((category) => [category.id, category.name])), [categories]);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadListings() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchApprovedClassifieds();
+        if (isActive) {
+          setListings(data);
+        }
+      } catch (caughtError) {
+        if (isActive) {
+          setError(caughtError instanceof Error ? caughtError.message : 'Unable to load classifieds.');
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadListings();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  const filteredListings = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return listings
+      .filter((listing) => {
+        if (quickFilter === 'jobs') return listing.kind === 'job';
+        return listing.kind === 'job' && listing.duration_type === quickFilter;
+      })
+      .filter((listing) => !cityFilter || listing.city_id === cityFilter)
+      .filter((listing) => !categoryFilter || listing.category_id === categoryFilter)
+      .filter((listing) => !durationFilter || listing.duration_type === durationFilter)
+      .filter((listing) => {
+        if (!query) return true;
+        return [
+          listing.title,
+          listing.description,
+          listing.organization_name ?? '',
+          listing.compensation_label ?? '',
+          cityNames.get(listing.city_id) ?? listing.city_id,
+          listing.category_id ? categoryNames.get(listing.category_id) ?? listing.category_id : '',
+        ].some((value) => value.toLowerCase().includes(query));
+      });
+  }, [categoryFilter, categoryNames, cityFilter, cityNames, durationFilter, listings, quickFilter, searchQuery]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title="Okanagan Trades Jobs | Hiring On-demand, Short-term and Full-time"
+        description="Browse moderated Okanagan trades job posts for on-demand shifts, short-term projects, and full-time roles. Looking for work? Create a worker profile."
+        path="/jobs"
+        keywords={[
+          'okanagan trades jobs',
+          'okanagan construction jobs',
+          'kelowna trades hiring',
+          'okanagan trades work',
+        ]}
+      />
+
+      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-10">
+        <div className="grid gap-8 border-b border-zinc-200 pb-10 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <div>
+            <SectionEyebrow
+              icon={BriefcaseBusiness}
+              className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+              iconClassName="h-3.5 w-3.5 text-orange-500"
+            >
+              Moderated job board
+            </SectionEyebrow>
+            <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl lg:text-6xl">
+              Trades jobs across the Okanagan
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-zinc-600">
+              Find approved local job posts for on-demand help, short-term projects, and full-time roles.
+            </p>
+          </div>
+          <Link
+            to="/jobs/post"
+            className="inline-flex min-h-12 items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-white shadow-[4px_4px_0px_0px_rgba(24,24,27,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:border-orange-500 hover:bg-orange-500 hover:shadow-none"
+          >
+            Post a job
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+
+        <Link
+          to="/workers"
+          className="mt-8 flex flex-wrap items-center justify-between gap-3 border border-zinc-200 bg-white px-5 py-4 shadow-sm transition-colors hover:border-zinc-900"
+        >
+          <span className="text-sm text-zinc-700">
+            <span className="font-semibold text-zinc-950">Looking to hire someone directly?</span> Browse available workers and tradespeople.
+          </span>
+          <span className="inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-900">
+            View workers
+            <ArrowRight className="h-4 w-4" />
+          </span>
+        </Link>
+
+        <section className="mt-8 border border-zinc-200 bg-white p-5 shadow-sm sm:p-6">
+          <div className="flex flex-wrap gap-2">
+            {quickFilters.map((filter) => (
+              <button
+                key={filter.value}
+                type="button"
+                onClick={() => setQuickFilter(filter.value)}
+                className={`inline-flex min-h-11 items-center border px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] transition-colors ${
+                  quickFilter === filter.value
+                    ? 'border-zinc-900 bg-zinc-900 text-white'
+                    : 'border-zinc-200 bg-zinc-50 text-zinc-600 hover:border-zinc-900 hover:bg-white hover:text-zinc-950'
+                }`}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_repeat(3,minmax(10rem,14rem))]">
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Search</label>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+                <input
+                  type="search"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Title, description, company, city, or trade"
+                  className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City</label>
+              <select value={cityFilter} onChange={(event) => setCityFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">All cities</option>
+                {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+              <select value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">All trades</option>
+                {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration</label>
+              <select value={durationFilter} onChange={(event) => setDurationFilter(event.target.value as '' | ClassifiedDurationType)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                {durationOptions.map((option) => <option key={option.value || 'all'} value={option.value}>{option.label}</option>)}
+              </select>
+            </div>
+          </div>
+        </section>
+
+        {error ? (
+          <div className="mt-8 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        {loading || directoryLoading ? (
+          <div className="mt-10 flex min-h-64 items-center justify-center">
+            <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          </div>
+        ) : (
+          <section className="mt-8">
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <h2 className="text-2xl font-bold text-zinc-950">{filteredListings.length} listings</h2>
+              <p className="hidden font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 sm:block">Approved posts only</p>
+            </div>
+
+            {filteredListings.length === 0 ? (
+              <div className="border border-zinc-200 bg-white px-6 py-12 text-center shadow-sm">
+                <p className="text-lg font-semibold text-zinc-950">No approved jobs match these filters.</p>
+                <p className="mt-2 text-sm text-zinc-500">Post a new job and it will appear here after admin review.</p>
+              </div>
+            ) : (
+              <div className="grid gap-5">
+                {filteredListings.map((listing) => (
+                  <div key={listing.id}>
+                    <ClassifiedCard
+                      listing={listing}
+                      cityName={cityNames.get(listing.city_id) ?? listing.city_id}
+                      categoryName={listing.category_id ? categoryNames.get(listing.category_id) ?? listing.category_id : 'General labour'}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/ClassifiedsPostPage.tsx
+++ b/src/pages/ClassifiedsPostPage.tsx
@@ -1,0 +1,293 @@
+import { type ChangeEvent, type FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowRight,
+  CalendarDays,
+  Mail,
+  Phone,
+  Send,
+} from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type ClassifiedDurationType,
+  type ClassifiedInput,
+  submitClassified,
+} from '@/src/lib/classifieds';
+
+const durationOptions: Array<{ value: ClassifiedDurationType; label: string }> = [
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+type JobFormState = {
+  title: string;
+  description: string;
+  cityId: string;
+  categoryId: string;
+  durationType: ClassifiedDurationType;
+  organizationName: string;
+  compensationLabel: string;
+  startDate: string;
+  endDate: string;
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string;
+};
+
+const initialFormState: JobFormState = {
+  title: '',
+  description: '',
+  cityId: '',
+  categoryId: '',
+  durationType: 'on_demand',
+  organizationName: '',
+  compensationLabel: '',
+  startDate: '',
+  endDate: '',
+  contactName: '',
+  contactEmail: '',
+  contactPhone: '',
+};
+
+function normalizeSubmission(formData: JobFormState): ClassifiedInput {
+  return {
+    kind: 'job',
+    title: formData.title,
+    description: formData.description,
+    cityId: formData.cityId,
+    categoryId: formData.categoryId || undefined,
+    durationType: formData.durationType,
+    organizationName: formData.organizationName || undefined,
+    compensationLabel: formData.compensationLabel || undefined,
+    startDate: formData.startDate || undefined,
+    endDate: formData.endDate || undefined,
+    contactName: formData.contactName,
+    contactEmail: formData.contactEmail || undefined,
+    contactPhone: formData.contactPhone || undefined,
+  };
+}
+
+export default function ClassifiedsPostPage() {
+  const navigate = useNavigate();
+  const { cities, categories, isLoading: directoryLoading } = useDirectoryData();
+  const [formData, setFormData] = useState<JobFormState>(initialFormState);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleChange(event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const hasContact = formData.contactEmail.trim().length > 0 || formData.contactPhone.trim().length > 0;
+
+    if (!hasContact) {
+      setError('Add an email or phone number so people can contact you.');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const result = await submitClassified(normalizeSubmission(formData));
+    setLoading(false);
+
+    if (!result.success) {
+      setError(result.error ?? 'Unable to submit the job right now.');
+      return;
+    }
+
+    navigate('/jobs/submitted');
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title="Post a Trades Job | Okanagan Trades"
+        description="Submit a moderated Okanagan trades job post for on-demand, short-term, or full-time work."
+        path="/jobs/post"
+        robots="noindex,follow"
+      />
+
+      <div className="mx-auto max-w-[86rem] px-4 sm:px-6 lg:px-10">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,0.75fr)_minmax(0,1.25fr)] lg:items-start">
+          <div>
+            <SectionEyebrow
+              icon={Send}
+              className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+              iconClassName="h-3.5 w-3.5 text-orange-500"
+            >
+              Public submission
+            </SectionEyebrow>
+            <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl">
+              Post a trades job
+            </h1>
+            <p className="mt-4 text-lg leading-8 text-zinc-600">
+              Submit a hiring post for local trades work. An admin reviews every job before it appears publicly.
+            </p>
+
+            <div className="mt-8 space-y-4 border-t border-zinc-200 pt-6">
+              {[
+                'On-demand shifts, short-term projects, and full-time roles are all welcome.',
+                'Approved jobs show your direct phone or email contact info.',
+                'Jobs expire automatically after 45 days unless reviewed again.',
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-3">
+                  <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-orange-500" />
+                  <p className="text-sm leading-6 text-zinc-600">{item}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-8 flex flex-col gap-3">
+              <Link
+                to="/jobs"
+                className="inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+              >
+                <ArrowRight className="h-3.5 w-3.5 rotate-180" />
+                Back to jobs
+              </Link>
+              <Link
+                to="/worker/start"
+                className="inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+              >
+                Available for work? Create a worker profile
+                <ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="border border-zinc-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+            <div className="grid gap-6 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Title *</label>
+                <input
+                  type="text"
+                  name="title"
+                  value={formData.title}
+                  onChange={handleChange}
+                  required
+                  maxLength={120}
+                  className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base font-medium text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
+                  placeholder="Journeyman plumber needed next week"
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City *</label>
+                <select name="cityId" value={formData.cityId} onChange={handleChange} required disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
+                  <option value="">Select city</option>
+                  {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+                <select name="categoryId" value={formData.categoryId} onChange={handleChange} disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
+                  <option value="">General labour</option>
+                  {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration *</label>
+                <select name="durationType" value={formData.durationType} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                  {durationOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Company</label>
+                <input
+                  type="text"
+                  name="organizationName"
+                  value={formData.organizationName}
+                  onChange={handleChange}
+                  className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
+                  placeholder="Company name"
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />Start date</label>
+                <input type="date" name="startDate" value={formData.startDate} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
+              </div>
+              <div>
+                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />End date</label>
+                <input type="date" name="endDate" value={formData.endDate} onChange={handleChange} min={formData.startDate || undefined} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
+              </div>
+
+              <div className="sm:col-span-2">
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Compensation or rate</label>
+                <input
+                  type="text"
+                  name="compensationLabel"
+                  value={formData.compensationLabel}
+                  onChange={handleChange}
+                  maxLength={120}
+                  className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
+                  placeholder="$30-$40/hr, project rate, or negotiable"
+                />
+              </div>
+
+              <div className="sm:col-span-2">
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Description *</label>
+                <textarea
+                  name="description"
+                  value={formData.description}
+                  onChange={handleChange}
+                  required
+                  rows={7}
+                  minLength={20}
+                  className="w-full resize-none border border-zinc-200 bg-zinc-50 px-4 py-4 text-base leading-7 text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white"
+                  placeholder="Describe the role, required experience, job site, schedule, and what to bring."
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Contact name *</label>
+                <input type="text" name="contactName" value={formData.contactName} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Name shown publicly" />
+              </div>
+              <div>
+                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Phone className="h-3.5 w-3.5" />Phone</label>
+                <input type="tel" name="contactPhone" value={formData.contactPhone} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+              </div>
+              <div className="sm:col-span-2">
+                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Mail className="h-3.5 w-3.5" />Email</label>
+                <input type="email" name="contactEmail" value={formData.contactEmail} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+              </div>
+            </div>
+
+            {error ? (
+              <div className="mt-6 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <p>{error}</p>
+              </div>
+            ) : null}
+
+            <button
+              type="submit"
+              disabled={loading || directoryLoading}
+              className="mt-8 inline-flex w-full min-h-14 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-colors hover:bg-zinc-800 disabled:pointer-events-none disabled:opacity-60"
+            >
+              {loading ? 'Submitting' : 'Submit for review'}
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </form>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/ClassifiedsPostPage.tsx
+++ b/src/pages/ClassifiedsPostPage.tsx
@@ -179,8 +179,9 @@ export default function ClassifiedsPostPage() {
           <form onSubmit={handleSubmit} className="border border-zinc-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
             <div className="grid gap-6 sm:grid-cols-2">
               <div className="sm:col-span-2">
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Title *</label>
+                <label htmlFor="classified-title" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Title *</label>
                 <input
+                  id="classified-title"
                   type="text"
                   name="title"
                   value={formData.title}
@@ -193,29 +194,30 @@ export default function ClassifiedsPostPage() {
               </div>
 
               <div>
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City *</label>
-                <select name="cityId" value={formData.cityId} onChange={handleChange} required disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
+                <label htmlFor="classified-city" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City *</label>
+                <select id="classified-city" name="cityId" value={formData.cityId} onChange={handleChange} required disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
                   <option value="">Select city</option>
                   {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
                 </select>
               </div>
               <div>
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
-                <select name="categoryId" value={formData.categoryId} onChange={handleChange} disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
+                <label htmlFor="classified-category" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+                <select id="classified-category" name="categoryId" value={formData.categoryId} onChange={handleChange} disabled={directoryLoading} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white disabled:opacity-60">
                   <option value="">General labour</option>
                   {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
                 </select>
               </div>
 
               <div>
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration *</label>
-                <select name="durationType" value={formData.durationType} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <label htmlFor="classified-duration" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Duration *</label>
+                <select id="classified-duration" name="durationType" value={formData.durationType} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
                   {durationOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
                 </select>
               </div>
               <div>
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Company</label>
+                <label htmlFor="classified-organization" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Company</label>
                 <input
+                  id="classified-organization"
                   type="text"
                   name="organizationName"
                   value={formData.organizationName}
@@ -226,17 +228,18 @@ export default function ClassifiedsPostPage() {
               </div>
 
               <div>
-                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />Start date</label>
-                <input type="date" name="startDate" value={formData.startDate} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
+                <label htmlFor="classified-start-date" className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />Start date</label>
+                <input id="classified-start-date" type="date" name="startDate" value={formData.startDate} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
               </div>
               <div>
-                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />End date</label>
-                <input type="date" name="endDate" value={formData.endDate} onChange={handleChange} min={formData.startDate || undefined} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
+                <label htmlFor="classified-end-date" className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><CalendarDays className="h-3.5 w-3.5" />End date</label>
+                <input id="classified-end-date" type="date" name="endDate" value={formData.endDate} onChange={handleChange} min={formData.startDate || undefined} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" />
               </div>
 
               <div className="sm:col-span-2">
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Compensation or rate</label>
+                <label htmlFor="classified-compensation" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Compensation or rate</label>
                 <input
+                  id="classified-compensation"
                   type="text"
                   name="compensationLabel"
                   value={formData.compensationLabel}
@@ -248,8 +251,9 @@ export default function ClassifiedsPostPage() {
               </div>
 
               <div className="sm:col-span-2">
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Description *</label>
+                <label htmlFor="classified-description" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Description *</label>
                 <textarea
+                  id="classified-description"
                   name="description"
                   value={formData.description}
                   onChange={handleChange}
@@ -262,16 +266,16 @@ export default function ClassifiedsPostPage() {
               </div>
 
               <div>
-                <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Contact name *</label>
-                <input type="text" name="contactName" value={formData.contactName} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Name shown publicly" />
+                <label htmlFor="classified-contact-name" className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Contact name *</label>
+                <input id="classified-contact-name" type="text" name="contactName" value={formData.contactName} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Name shown publicly" />
               </div>
               <div>
-                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Phone className="h-3.5 w-3.5" />Phone</label>
-                <input type="tel" name="contactPhone" value={formData.contactPhone} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+                <label htmlFor="classified-contact-phone" className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Phone className="h-3.5 w-3.5" />Phone</label>
+                <input id="classified-contact-phone" type="tel" name="contactPhone" value={formData.contactPhone} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
               </div>
               <div className="sm:col-span-2">
-                <label className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Mail className="h-3.5 w-3.5" />Email</label>
-                <input type="email" name="contactEmail" value={formData.contactEmail} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+                <label htmlFor="classified-contact-email" className="mb-2 flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500"><Mail className="h-3.5 w-3.5" />Email</label>
+                <input id="classified-contact-email" type="email" name="contactEmail" value={formData.contactEmail} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
               </div>
             </div>
 

--- a/src/pages/ClassifiedsPostPage.tsx
+++ b/src/pages/ClassifiedsPostPage.tsx
@@ -94,6 +94,11 @@ export default function ClassifiedsPostPage() {
       return;
     }
 
+    if (formData.startDate && formData.endDate && new Date(formData.endDate) < new Date(formData.startDate)) {
+      setError('End date must be on or after the start date.');
+      return;
+    }
+
     setLoading(true);
     setError(null);
 

--- a/src/pages/ClassifiedsSubmittedPage.tsx
+++ b/src/pages/ClassifiedsSubmittedPage.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom';
+import { ArrowRight, CheckCircle2 } from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+
+export default function ClassifiedsSubmittedPage() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title="Job Submitted | Okanagan Trades"
+        description="Your Okanagan Trades job post was submitted for review."
+        path="/jobs/submitted"
+        robots="noindex,nofollow"
+      />
+
+      <div className="mx-auto flex max-w-3xl flex-col items-center px-4 text-center sm:px-6 lg:px-8">
+        <div className="flex h-16 w-16 items-center justify-center border-2 border-zinc-900 bg-white shadow-[5px_5px_0px_0px_rgba(24,24,27,1)]">
+          <CheckCircle2 className="h-7 w-7 text-emerald-600" strokeWidth={2.2} />
+        </div>
+        <SectionEyebrow
+          icon={CheckCircle2}
+          className="mt-8 inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+          iconClassName="h-3.5 w-3.5 text-emerald-600"
+        >
+          Submitted for review
+        </SectionEyebrow>
+        <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl">
+          Your job is pending approval
+        </h1>
+        <p className="mt-5 text-lg leading-8 text-zinc-600">
+          An admin will review it before it appears on the public jobs page. Approved jobs show your direct contact info for local trades hiring.
+        </p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Link
+            to="/jobs"
+            className="inline-flex min-h-12 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-white transition-colors hover:bg-zinc-800"
+          >
+            Browse jobs
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+          <Link
+            to="/jobs/post"
+            className="inline-flex min-h-12 items-center justify-center gap-3 border border-zinc-200 bg-white px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950"
+          >
+            Post another
+          </Link>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/WorkerDashboardPage.tsx
+++ b/src/pages/WorkerDashboardPage.tsx
@@ -40,6 +40,9 @@ const availabilityOptions: Array<{ value: WorkerAvailability; label: string }> =
   { value: 'full_time', label: 'Full-time' },
 ];
 
+const PHOTO_MIMES = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_PHOTO_BYTES = 5 * 1024 * 1024;
+
 type WorkerFormState = {
   displayName: string;
   headline: string;
@@ -209,6 +212,17 @@ export default function WorkerDashboardPage() {
   async function handlePhotoChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     if (!file || !user) return;
+
+    if (file.size > MAX_PHOTO_BYTES) {
+      setError('Photo must be under 5MB.');
+      event.target.value = '';
+      return;
+    }
+    if (file.type && !PHOTO_MIMES.includes(file.type)) {
+      setError('Upload a JPEG, PNG, or WebP photo.');
+      event.target.value = '';
+      return;
+    }
 
     setUploading(true);
     setError(null);

--- a/src/pages/WorkerDashboardPage.tsx
+++ b/src/pages/WorkerDashboardPage.tsx
@@ -1,0 +1,496 @@
+import { type ChangeEvent, type FormEvent, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowRight,
+  CheckCircle2,
+  Clock3,
+  ExternalLink,
+  Save,
+  Sparkles,
+  UserRound,
+  XCircle,
+} from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { useDirectoryData } from '@/src/directory-data';
+import { isSupabaseConfigured, supabase } from '@/src/lib/supabase';
+import {
+  type WorkerAvailability,
+  type WorkerProfile,
+  fetchMyWorkerProfile,
+  upsertWorkerProfile,
+  uploadResume,
+  uploadWorkerPhoto,
+} from '@/src/lib/workerProfiles';
+import {
+  type OnboardingDraft,
+  clearOnboardingDraft,
+  clearResumeBlob,
+  loadOnboardingDraft,
+  loadResumeBlob,
+} from '@/src/lib/resumeParsing';
+
+const availabilityOptions: Array<{ value: WorkerAvailability; label: string }> = [
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+type WorkerFormState = {
+  displayName: string;
+  headline: string;
+  cityId: string;
+  categoryId: string;
+  availability: WorkerAvailability;
+  serviceAreas: string;
+  skills: string;
+  rateLabel: string;
+  yearsExperience: string;
+  bio: string;
+  photoUrl: string;
+  resumePath: string;
+  openToWork: boolean;
+  contactName: string;
+  contactEmail: string;
+  contactPhone: string;
+};
+
+const initialFormState: WorkerFormState = {
+  displayName: '',
+  headline: '',
+  cityId: '',
+  categoryId: '',
+  availability: 'on_demand',
+  serviceAreas: '',
+  skills: '',
+  rateLabel: '',
+  yearsExperience: '',
+  bio: '',
+  photoUrl: '',
+  resumePath: '',
+  openToWork: true,
+  contactName: '',
+  contactEmail: '',
+  contactPhone: '',
+};
+
+function profileToForm(profile: WorkerProfile): WorkerFormState {
+  return {
+    displayName: profile.display_name,
+    headline: profile.headline,
+    cityId: profile.city_id,
+    categoryId: profile.category_id ?? '',
+    availability: profile.availability,
+    serviceAreas: profile.service_areas.join(', '),
+    skills: profile.skills.join(', '),
+    rateLabel: profile.rate_label ?? '',
+    yearsExperience: profile.years_experience !== null ? String(profile.years_experience) : '',
+    bio: profile.bio,
+    photoUrl: profile.photo_url ?? '',
+    resumePath: profile.resume_path ?? '',
+    openToWork: profile.open_to_work,
+    contactName: profile.contact_name,
+    contactEmail: profile.contact_email ?? '',
+    contactPhone: profile.contact_phone ?? '',
+  };
+}
+
+function draftToForm(draft: OnboardingDraft): WorkerFormState {
+  return {
+    displayName: draft.display_name ?? '',
+    headline: draft.headline ?? '',
+    cityId: draft.city_id ?? '',
+    categoryId: draft.category_id ?? '',
+    availability: draft.availability,
+    serviceAreas: draft.service_areas.join(', '),
+    skills: draft.skills.join(', '),
+    rateLabel: draft.rate_label ?? '',
+    yearsExperience: draft.years_experience !== null ? String(draft.years_experience) : '',
+    bio: draft.bio ?? '',
+    photoUrl: '',
+    resumePath: '',
+    openToWork: draft.open_to_work,
+    contactName: draft.display_name ?? '',
+    contactEmail: draft.contact_email ?? '',
+    contactPhone: draft.contact_phone ?? '',
+  };
+}
+
+function parseList(value: string) {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function statusBadge(status: WorkerProfile['status']) {
+  if (status === 'approved') {
+    return { icon: CheckCircle2, label: 'Approved and live', className: 'border-emerald-200 bg-emerald-50 text-emerald-800' };
+  }
+  if (status === 'rejected') {
+    return { icon: XCircle, label: 'Needs changes', className: 'border-rose-200 bg-rose-50 text-rose-800' };
+  }
+  if (status === 'archived') {
+    return { icon: XCircle, label: 'Archived', className: 'border-zinc-200 bg-zinc-100 text-zinc-600' };
+  }
+  return { icon: Clock3, label: 'Pending review', className: 'border-amber-200 bg-amber-50 text-amber-800' };
+}
+
+export default function WorkerDashboardPage() {
+  const { user, loading: authLoading } = useAuth();
+  const { cities, categories, isLoading: directoryLoading } = useDirectoryData();
+  const toolsAvailable = Boolean(supabase && isSupabaseConfigured());
+
+  const [profile, setProfile] = useState<WorkerProfile | null>(null);
+  const [formData, setFormData] = useState<WorkerFormState>(initialFormState);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingResume, setPendingResume] = useState<File | null>(null);
+  const [importedFromResume, setImportedFromResume] = useState(false);
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadProfile() {
+      if (!toolsAvailable || !user) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const existing = await fetchMyWorkerProfile(user.id);
+        if (!isActive) return;
+        setProfile(existing);
+        if (existing) {
+          setFormData(profileToForm(existing));
+        } else {
+          // No profile yet — adopt an onboarding draft if the user just came
+          // through /worker/start and signed in.
+          const draft = loadOnboardingDraft();
+          if (draft) {
+            setFormData(draftToForm(draft));
+            setImportedFromResume(true);
+            const resumeFile = await loadResumeBlob();
+            if (isActive && resumeFile) {
+              setPendingResume(resumeFile);
+            }
+          }
+        }
+      } catch (caughtError) {
+        if (isActive) {
+          setError(caughtError instanceof Error ? caughtError.message : 'Failed to load your profile.');
+        }
+      } finally {
+        if (isActive) setLoading(false);
+      }
+    }
+
+    void loadProfile();
+
+    return () => {
+      isActive = false;
+    };
+  }, [toolsAvailable, user]);
+
+  const badge = useMemo(() => (profile ? statusBadge(profile.status) : null), [profile]);
+
+  function handleChange(event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+  }
+
+  async function handlePhotoChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file || !user) return;
+
+    setUploading(true);
+    setError(null);
+    try {
+      const url = await uploadWorkerPhoto(user.id, file);
+      setFormData((current) => ({ ...current, photoUrl: url }));
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to upload the photo.');
+    } finally {
+      setUploading(false);
+      event.target.value = '';
+    }
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user || !toolsAvailable) return;
+
+    const hasContact = formData.contactEmail.trim().length > 0 || formData.contactPhone.trim().length > 0;
+    if (!hasContact) {
+      setError('Add an email or phone number so people can contact you.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setSaveSuccess(false);
+
+    try {
+      // Upload the resume carried over from onboarding (best-effort).
+      let resumePath = formData.resumePath || null;
+      if (pendingResume) {
+        try {
+          resumePath = await uploadResume(user.id, pendingResume);
+        } catch {
+          // Don't block publishing the profile if the resume upload fails.
+          resumePath = formData.resumePath || null;
+        }
+      }
+
+      const yearsValue = formData.yearsExperience.trim();
+      const saved = await upsertWorkerProfile(user.id, {
+        displayName: formData.displayName,
+        headline: formData.headline,
+        cityId: formData.cityId,
+        categoryId: formData.categoryId || undefined,
+        availability: formData.availability,
+        serviceAreas: parseList(formData.serviceAreas),
+        skills: parseList(formData.skills),
+        rateLabel: formData.rateLabel || undefined,
+        yearsExperience: yearsValue ? Number(yearsValue) : null,
+        bio: formData.bio,
+        photoUrl: formData.photoUrl || null,
+        resumePath,
+        openToWork: formData.openToWork,
+        contactName: formData.contactName,
+        contactEmail: formData.contactEmail || undefined,
+        contactPhone: formData.contactPhone || undefined,
+      });
+      setProfile(saved);
+      setFormData(profileToForm(saved));
+      setPendingResume(null);
+      setImportedFromResume(false);
+      clearOnboardingDraft();
+      void clearResumeBlob();
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 4000);
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Failed to save your profile.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (authLoading || directoryLoading || loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA]">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900" />
+      </div>
+    );
+  }
+
+  if (!toolsAvailable) {
+    return (
+      <div className="min-h-screen bg-[#FAFAFA] px-4 py-24">
+        <Seo title="Worker Dashboard | Okanagan Trades" description="Manage your worker profile." path="/worker/dashboard" robots="noindex,nofollow" />
+        <div className="mx-auto max-w-2xl border-2 border-zinc-900 bg-white p-8 shadow-[8px_8px_0px_0px_rgba(24,24,27,1)] sm:p-10">
+          <h1 className="text-4xl font-bold uppercase tracking-tight text-zinc-950">Worker dashboard is offline.</h1>
+          <p className="mt-4 text-lg leading-8 text-zinc-600">This environment does not have the backend configured yet.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo title="Worker Dashboard | Okanagan Trades" description="Create and manage your worker profile." path="/worker/dashboard" robots="noindex,nofollow" />
+
+      <div className="mx-auto max-w-[86rem] px-4 sm:px-6 lg:px-10">
+        <div className="border-b border-zinc-200 pb-8">
+          <SectionEyebrow
+            icon={UserRound}
+            className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+            iconClassName="h-3.5 w-3.5 text-orange-500"
+          >
+            Worker profile
+          </SectionEyebrow>
+          <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl">
+            {profile ? 'Manage your profile' : 'Create your worker profile'}
+          </h1>
+          <p className="mt-4 max-w-3xl text-lg leading-8 text-zinc-600">
+            Tell homeowners and contractors what you do. An admin reviews every profile before it appears publicly,
+            and any edits re-enter review.
+          </p>
+
+          {badge ? (
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <span className={`inline-flex items-center gap-2 border px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] ${badge.className}`}>
+                <badge.icon className="h-3.5 w-3.5" />
+                {badge.label}
+              </span>
+              {profile?.status === 'approved' ? (
+                <Link to={`/workers/${profile.id}`} className="inline-flex items-center gap-1.5 font-medium text-zinc-900 underline underline-offset-4 hover:text-orange-600">
+                  View public profile
+                  <ExternalLink className="h-4 w-4" strokeWidth={2.2} />
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+
+          {profile?.status === 'rejected' && profile.rejection_reason ? (
+            <div className="mt-4 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p><span className="font-semibold">Reviewer note:</span> {profile.rejection_reason}</p>
+            </div>
+          ) : null}
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+          {error ? (
+            <div className="mb-6 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>{error}</p>
+            </div>
+          ) : null}
+          {saveSuccess ? (
+            <div className="mb-6 flex items-start gap-3 border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-700">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>Saved. Your profile is pending admin review.</p>
+            </div>
+          ) : null}
+          {importedFromResume ? (
+            <div className="mb-6 flex items-start gap-3 border border-orange-200 bg-orange-50 px-4 py-4 text-sm text-orange-800">
+              <Sparkles className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>
+                Imported from your resume{pendingResume ? ` (${pendingResume.name})` : ''}. Review the details below, then publish to send it for review.
+              </p>
+            </div>
+          ) : null}
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Display name *</label>
+              <input type="text" name="displayName" value={formData.displayName} onChange={handleChange} required maxLength={120} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base font-medium text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Jordan the carpenter" />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Headline *</label>
+              <input type="text" name="headline" value={formData.headline} onChange={handleChange} required maxLength={140} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Red Seal carpenter, 8 yrs framing and finishing" />
+            </div>
+
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City *</label>
+              <select name="cityId" value={formData.cityId} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">Select city</option>
+                {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+              <select name="categoryId" value={formData.categoryId} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">General labour</option>
+                {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+              </select>
+            </div>
+
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Availability *</label>
+              <select name="availability" value={formData.availability} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                {availabilityOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Years of experience</label>
+              <input type="number" name="yearsExperience" value={formData.yearsExperience} onChange={handleChange} min={0} max={70} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="8" />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Rate</label>
+              <input type="text" name="rateLabel" value={formData.rateLabel} onChange={handleChange} maxLength={120} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="$32/hr or day rate negotiable" />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Skills (comma separated)</label>
+              <input type="text" name="skills" value={formData.skills} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Framing, finishing, decks, tickets: WHMIS, fall protection" />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Service areas (comma separated)</label>
+              <input type="text" name="serviceAreas" value={formData.serviceAreas} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Kelowna, West Kelowna, Lake Country" />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">About you *</label>
+              <textarea name="bio" value={formData.bio} onChange={handleChange} required rows={7} minLength={20} className="w-full resize-none border border-zinc-200 bg-zinc-50 px-4 py-4 text-base leading-7 text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Describe your experience, the work you take on, tools and transport, and what makes you reliable." />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Profile photo</label>
+              <div className="flex flex-wrap items-center gap-4">
+                <div className="h-24 w-24 shrink-0 overflow-hidden border border-zinc-200 bg-zinc-100">
+                  {formData.photoUrl ? (
+                    <img src={formData.photoUrl} alt="Profile preview" className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-zinc-300"><UserRound className="h-10 w-10" strokeWidth={1.2} /></div>
+                  )}
+                </div>
+                <label className="inline-flex cursor-pointer items-center gap-2 border border-zinc-200 bg-white px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950">
+                  {uploading ? 'Uploading...' : formData.photoUrl ? 'Replace photo' : 'Upload photo'}
+                  <input type="file" accept="image/jpeg,image/png,image/webp" onChange={handlePhotoChange} disabled={uploading} className="hidden" />
+                </label>
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Contact name *</label>
+              <input type="text" name="contactName" value={formData.contactName} onChange={handleChange} required className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Name shown publicly" />
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Phone</label>
+              <input type="tel" name="contactPhone" value={formData.contactPhone} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Email</label>
+              <input type="email" name="contactEmail" value={formData.contactEmail} onChange={handleChange} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white" placeholder="Shown publicly after approval" />
+            </div>
+          </div>
+
+          <label className="mt-8 flex items-center gap-3 border border-zinc-200 bg-zinc-50 px-4 py-4 text-sm text-zinc-700">
+            <input
+              type="checkbox"
+              checked={formData.openToWork}
+              onChange={(event) => setFormData((current) => ({ ...current, openToWork: event.target.checked }))}
+              className="h-4 w-4"
+            />
+            I'm available for work now (uncheck to hide your profile without deleting it)
+          </label>
+
+          <button
+            type="submit"
+            disabled={saving || uploading}
+            className="mt-6 inline-flex w-full min-h-14 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-colors hover:bg-zinc-800 disabled:pointer-events-none disabled:opacity-60"
+          >
+            {saving ? 'Saving...' : profile ? 'Save and resubmit for review' : 'Submit for review'}
+            {saving ? null : <Save className="h-4 w-4" strokeWidth={2.2} />}
+          </button>
+        </form>
+
+        <Link
+          to="/workers"
+          className="mt-8 inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+        >
+          Browse all workers
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/WorkerOnboardingPage.tsx
+++ b/src/pages/WorkerOnboardingPage.tsx
@@ -1,0 +1,465 @@
+import { type ChangeEvent, type FormEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowRight,
+  FileText,
+  Sparkles,
+  Upload,
+  UserRound,
+} from 'lucide-react';
+import { motion } from 'motion/react';
+
+import GoogleIcon from '@/src/components/GoogleIcon';
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { useAuth } from '@/src/contexts/AuthContext';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type OnboardingDraft,
+  type ParsedResumeDraft,
+  clearOnboardingDraft,
+  clearResumeBlob,
+  parseResume,
+  saveOnboardingDraft,
+  saveResumeBlob,
+} from '@/src/lib/resumeParsing';
+import type { WorkerAvailability } from '@/src/lib/workerProfiles';
+
+type Step = 'source' | 'parsing' | 'wizard' | 'auth';
+
+const availabilityOptions: Array<{ value: WorkerAvailability; label: string }> = [
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+const PUBLISH_REDIRECT = '/worker/dashboard';
+
+const inputClass =
+  'w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none transition-colors focus:border-zinc-900 focus:bg-white';
+const labelClass = 'mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500';
+
+export default function WorkerOnboardingPage() {
+  const navigate = useNavigate();
+  const { user, signInWithGoogle, signInWithMagicLink } = useAuth();
+  const { cities, categories } = useDirectoryData();
+
+  const [step, setStep] = useState<Step>('source');
+  const [file, setFile] = useState<File | null>(null);
+  const [pastedText, setPastedText] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [draft, setDraft] = useState<ParsedResumeDraft | null>(null);
+  const [wizard, setWizard] = useState({
+    displayName: '',
+    headline: '',
+    cityId: '',
+    categoryId: '',
+    availability: 'on_demand' as WorkerAvailability,
+    rateLabel: '',
+    contactEmail: '',
+    contactPhone: '',
+    openToWork: true,
+  });
+
+  const [magicEmail, setMagicEmail] = useState('');
+  const [magicSent, setMagicSent] = useState(false);
+  const [authBusy, setAuthBusy] = useState(false);
+
+  const skillsPreview = useMemo(() => (draft?.skills ?? []).slice(0, 8), [draft]);
+
+  function applyDraftToWizard(parsed: ParsedResumeDraft) {
+    setWizard((current) => ({
+      ...current,
+      displayName: parsed.display_name ?? '',
+      headline: parsed.headline ?? '',
+      cityId: parsed.city_id ?? '',
+      categoryId: parsed.category_id ?? '',
+      rateLabel: parsed.rate_label ?? '',
+      contactEmail: parsed.contact_email ?? '',
+      contactPhone: parsed.contact_phone ?? '',
+    }));
+  }
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const selected = event.target.files?.[0] ?? null;
+    setFile(selected);
+    setError(null);
+  }
+
+  async function runParse(source: { file?: File; text?: string }) {
+    setStep('parsing');
+    setParseError(null);
+    const { draft: parsed, error: parseErr } = await parseResume(source, categories, cities);
+    setDraft(parsed);
+    applyDraftToWizard(parsed);
+    if (parseErr) setParseError(parseErr);
+    setStep('wizard');
+  }
+
+  function handleSkip() {
+    const empty: ParsedResumeDraft = {
+      display_name: null,
+      headline: null,
+      category_id: null,
+      city_id: null,
+      skills: [],
+      years_experience: null,
+      bio: null,
+      service_areas: [],
+      rate_label: null,
+      contact_email: null,
+      contact_phone: null,
+    };
+    setDraft(empty);
+    setFile(null);
+    setStep('wizard');
+  }
+
+  function handleWizardChange(event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
+    const { name, value, type, checked } = event.target as HTMLInputElement;
+    setWizard((current) => ({ ...current, [name]: type === 'checkbox' ? checked : value }));
+  }
+
+  async function persistDraft(): Promise<OnboardingDraft> {
+    const merged: OnboardingDraft = {
+      display_name: wizard.displayName.trim() || draft?.display_name || null,
+      headline: wizard.headline.trim() || draft?.headline || null,
+      category_id: wizard.categoryId || null,
+      city_id: wizard.cityId || null,
+      skills: draft?.skills ?? [],
+      years_experience: draft?.years_experience ?? null,
+      bio: draft?.bio ?? null,
+      service_areas: draft?.service_areas ?? [],
+      rate_label: wizard.rateLabel.trim() || null,
+      contact_email: wizard.contactEmail.trim() || null,
+      contact_phone: wizard.contactPhone.trim() || null,
+      availability: wizard.availability,
+      open_to_work: wizard.openToWork,
+      resume_file_name: file?.name ?? null,
+    };
+
+    saveOnboardingDraft(merged);
+    if (file) {
+      await saveResumeBlob(file);
+    } else {
+      await clearResumeBlob();
+    }
+    return merged;
+  }
+
+  async function handleWizardSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    if (!wizard.displayName.trim() || !wizard.headline.trim()) {
+      setError('Add your name and a short headline.');
+      return;
+    }
+    if (!wizard.cityId) {
+      setError('Select the city you work in.');
+      return;
+    }
+    if (!wizard.contactEmail.trim() && !wizard.contactPhone.trim()) {
+      setError('Add an email or phone number so people can reach you.');
+      return;
+    }
+
+    await persistDraft();
+
+    // Already signed in? Skip straight to the dashboard to review and publish.
+    if (user) {
+      navigate(PUBLISH_REDIRECT);
+      return;
+    }
+    setStep('auth');
+  }
+
+  async function handleGoogle() {
+    setAuthBusy(true);
+    setError(null);
+    const { error: googleError } = await signInWithGoogle(PUBLISH_REDIRECT);
+    if (googleError) {
+      setError(googleError.message);
+      setAuthBusy(false);
+    }
+  }
+
+  async function handleMagicLink(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!magicEmail.trim()) return;
+    setAuthBusy(true);
+    setError(null);
+    const { error: magicError } = await signInWithMagicLink(magicEmail.trim(), PUBLISH_REDIRECT);
+    setAuthBusy(false);
+    if (magicError) {
+      setError(magicError.message);
+      return;
+    }
+    setMagicSent(true);
+  }
+
+  // If they were already signed in when landing here mid-flow, nothing else to do.
+  useEffect(() => {
+    if (step === 'auth' && user) {
+      navigate(PUBLISH_REDIRECT);
+    }
+  }, [navigate, step, user]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title="Get Hired Fast | Okanagan Trades Worker Profile"
+        description="Upload your resume and we'll build your worker profile in seconds. Answer a few quick questions and get listed for local trades work."
+        path="/worker/start"
+        robots="noindex,follow"
+      />
+
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <SectionEyebrow
+          icon={Sparkles}
+          className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+          iconClassName="h-3.5 w-3.5 text-orange-500"
+        >
+          Resume to profile
+        </SectionEyebrow>
+        <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl">
+          Get listed for work in minutes
+        </h1>
+        <p className="mt-4 text-lg leading-8 text-zinc-600">
+          Drop in your resume and we'll draft your profile automatically. Answer a few quick questions, then sign in
+          once to publish.
+        </p>
+
+        {error ? (
+          <div className="mt-6 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        {step === 'source' ? (
+          <div className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex w-full flex-col items-center justify-center gap-3 border-2 border-dashed border-zinc-300 bg-zinc-50 px-6 py-10 text-center transition-colors hover:border-zinc-900 hover:bg-white"
+            >
+              <Upload className="h-8 w-8 text-zinc-400" />
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-700">
+                {file ? file.name : 'Upload a PDF or DOCX resume'}
+              </span>
+              <span className="text-sm text-zinc-500">Click to browse</span>
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+              onChange={handleFileChange}
+              className="hidden"
+            />
+
+            <div className="my-6 flex items-center gap-4 text-zinc-400">
+              <span className="h-px flex-1 bg-zinc-200" />
+              <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em]">or paste it</span>
+              <span className="h-px flex-1 bg-zinc-200" />
+            </div>
+
+            <textarea
+              value={pastedText}
+              onChange={(event) => setPastedText(event.target.value)}
+              rows={6}
+              className={`${inputClass} resize-none`}
+              placeholder="Paste your resume text here..."
+            />
+
+            <button
+              type="button"
+              disabled={!file && !pastedText.trim()}
+              onClick={() => void runParse(file ? { file } : { text: pastedText })}
+              className="mt-6 inline-flex w-full min-h-14 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-colors hover:bg-zinc-800 disabled:pointer-events-none disabled:opacity-60"
+            >
+              Build my profile
+              <ArrowRight className="h-4 w-4" />
+            </button>
+
+            <button
+              type="button"
+              onClick={handleSkip}
+              className="mt-4 inline-flex w-full items-center justify-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+            >
+              Skip and fill the form manually
+            </button>
+          </div>
+        ) : null}
+
+        {step === 'parsing' ? (
+          <div className="mt-8 flex min-h-64 flex-col items-center justify-center gap-4 border border-zinc-200 bg-white p-10 text-center shadow-sm">
+            <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900" />
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Reading your resume</p>
+          </div>
+        ) : null}
+
+        {step === 'wizard' ? (
+          <form onSubmit={handleWizardSubmit} className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+            {parseError ? (
+              <div className="mb-6 flex items-start gap-3 border border-amber-200 bg-amber-50 px-4 py-4 text-sm text-amber-800">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <p>{parseError} You can fill everything in below.</p>
+              </div>
+            ) : draft && (draft.display_name || draft.headline || draft.skills.length > 0) ? (
+              <div className="mb-6 flex items-start gap-3 border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-800">
+                <Sparkles className="mt-0.5 h-4 w-4 shrink-0" />
+                <p>We drafted your profile from your resume. Confirm the essentials below.</p>
+              </div>
+            ) : null}
+
+            <div className="grid gap-6 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <label className={labelClass}>Your name *</label>
+                <input name="displayName" value={wizard.displayName} onChange={handleWizardChange} required className={inputClass} placeholder="Jordan the carpenter" />
+              </div>
+              <div className="sm:col-span-2">
+                <label className={labelClass}>Headline *</label>
+                <input name="headline" value={wizard.headline} onChange={handleWizardChange} required maxLength={140} className={inputClass} placeholder="Red Seal carpenter, 8 yrs framing and finishing" />
+              </div>
+              <div>
+                <label className={labelClass}>Primary trade</label>
+                <select name="categoryId" value={wizard.categoryId} onChange={handleWizardChange} className={inputClass}>
+                  <option value="">General labour</option>
+                  {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>City *</label>
+                <select name="cityId" value={wizard.cityId} onChange={handleWizardChange} required className={inputClass}>
+                  <option value="">Select city</option>
+                  {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Availability *</label>
+                <select name="availability" value={wizard.availability} onChange={handleWizardChange} required className={inputClass}>
+                  {availabilityOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Rate</label>
+                <input name="rateLabel" value={wizard.rateLabel} onChange={handleWizardChange} className={inputClass} placeholder="$32/hr or negotiable" />
+              </div>
+              <div>
+                <label className={labelClass}>Phone</label>
+                <input name="contactPhone" type="tel" value={wizard.contactPhone} onChange={handleWizardChange} className={inputClass} placeholder="(250) 555-0000" />
+              </div>
+              <div>
+                <label className={labelClass}>Email</label>
+                <input name="contactEmail" type="email" value={wizard.contactEmail} onChange={handleWizardChange} className={inputClass} placeholder="you@email.com" />
+              </div>
+            </div>
+
+            {skillsPreview.length > 0 ? (
+              <div className="mt-6">
+                <p className={labelClass}>Skills we found</p>
+                <div className="flex flex-wrap gap-2">
+                  {skillsPreview.map((skill) => (
+                    <span key={skill} className="inline-flex items-center border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm text-zinc-700">{skill}</span>
+                  ))}
+                </div>
+                <p className="mt-2 text-xs text-zinc-500">You can edit these and your full bio on the next screen.</p>
+              </div>
+            ) : null}
+
+            <label className="mt-6 flex items-center gap-3 text-sm text-zinc-700">
+              <input type="checkbox" name="openToWork" checked={wizard.openToWork} onChange={handleWizardChange} className="h-4 w-4" />
+              I'm available for work now
+            </label>
+
+            <button
+              type="submit"
+              className="mt-8 inline-flex w-full min-h-14 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-6 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-white transition-colors hover:bg-zinc-800"
+            >
+              Continue to publish
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </form>
+        ) : null}
+
+        {step === 'auth' ? (
+          <div className="mt-8 border border-zinc-200 bg-white p-6 shadow-sm sm:p-8">
+            <div className="flex items-center gap-3">
+              <FileText className="h-5 w-5 text-orange-500" />
+              <p className="text-sm text-zinc-600">Your profile is ready{file ? ` (with ${file.name})` : ''}. Sign in once to publish it.</p>
+            </div>
+
+            {magicSent ? (
+              <div className="mt-6 flex items-start gap-3 border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-800">
+                <UserRound className="mt-0.5 h-4 w-4 shrink-0" />
+                <p>Check your email for a sign-in link. Open it to finish publishing your profile.</p>
+              </div>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={() => void handleGoogle()}
+                  disabled={authBusy}
+                  className="mt-6 inline-flex w-full min-h-12 items-center justify-center gap-3 border border-zinc-900 bg-white px-5 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-900 transition-colors hover:bg-zinc-50 disabled:opacity-60"
+                >
+                  <GoogleIcon />
+                  Continue with Google
+                </button>
+
+                <div className="my-6 flex items-center gap-4 text-zinc-400">
+                  <span className="h-px flex-1 bg-zinc-200" />
+                  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.18em]">or</span>
+                  <span className="h-px flex-1 bg-zinc-200" />
+                </div>
+
+                <form onSubmit={handleMagicLink}>
+                  <label className={labelClass}>Email me a sign-in link</label>
+                  <input type="email" value={magicEmail} onChange={(event) => setMagicEmail(event.target.value)} required className={inputClass} placeholder="you@email.com" />
+                  <button
+                    type="submit"
+                    disabled={authBusy}
+                    className="mt-4 inline-flex w-full min-h-12 items-center justify-center gap-3 border border-zinc-900 bg-zinc-900 px-5 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-white transition-colors hover:bg-zinc-800 disabled:opacity-60"
+                  >
+                    Send magic link
+                    <ArrowRight className="h-4 w-4" />
+                  </button>
+                </form>
+
+                <p className="mt-6 text-center text-sm text-zinc-500">
+                  Prefer a password?{' '}
+                  <Link to={`/login?redirect=${encodeURIComponent(PUBLISH_REDIRECT)}`} className="font-medium text-zinc-900 underline underline-offset-4 hover:text-orange-600">
+                    Sign in here
+                  </Link>
+                </p>
+              </>
+            )}
+          </div>
+        ) : null}
+
+        <button
+          type="button"
+          onClick={() => {
+            clearOnboardingDraft();
+            void clearResumeBlob();
+            navigate('/workers');
+          }}
+          className="mt-8 inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+        >
+          <ArrowRight className="h-3.5 w-3.5 rotate-180" />
+          Back to workers
+        </button>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/WorkerProfilePage.tsx
+++ b/src/pages/WorkerProfilePage.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import {
+  AlertCircle,
+  ArrowRight,
+  CalendarClock,
+  Hammer,
+  Mail,
+  MapPin,
+  Phone,
+  UserRound,
+} from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import { availabilityLabel } from '@/src/components/WorkerCard';
+import { useDirectoryData } from '@/src/directory-data';
+import { type WorkerProfile, fetchWorkerProfileById } from '@/src/lib/workerProfiles';
+
+export default function WorkerProfilePage() {
+  const { workerId } = useParams<{ workerId: string }>();
+  const { cities, categories, isLoading: directoryLoading } = useDirectoryData();
+  const [worker, setWorker] = useState<WorkerProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cityNames = useMemo(() => new Map(cities.map((city) => [city.id, city.name])), [cities]);
+  const categoryNames = useMemo(
+    () => new Map(categories.map((category) => [category.id, category.name])),
+    [categories],
+  );
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadWorker() {
+      if (!workerId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchWorkerProfileById(workerId);
+        if (isActive) {
+          setWorker(data);
+        }
+      } catch (caughtError) {
+        if (isActive) {
+          setError(caughtError instanceof Error ? caughtError.message : 'Unable to load this profile.');
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadWorker();
+
+    return () => {
+      isActive = false;
+    };
+  }, [workerId]);
+
+  if (loading || directoryLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA]">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+      </div>
+    );
+  }
+
+  if (error || !worker || worker.status !== 'approved') {
+    return (
+      <div className="min-h-screen bg-[#FAFAFA] px-4 py-24 font-sans text-zinc-900">
+        <Seo title="Worker not found | Okanagan Trades" description="This worker profile is unavailable." path="/workers" robots="noindex,follow" />
+        <div className="mx-auto max-w-2xl border border-zinc-200 bg-white p-8 text-center shadow-sm">
+          <AlertCircle className="mx-auto h-8 w-8 text-zinc-400" />
+          <h1 className="mt-4 text-2xl font-bold text-zinc-950">This profile isn't available</h1>
+          <p className="mt-2 text-sm text-zinc-500">{error ?? 'It may have been removed or is awaiting review.'}</p>
+          <Link
+            to="/workers"
+            className="mt-6 inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-900 bg-zinc-900 px-5 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-white transition-colors hover:bg-zinc-800"
+          >
+            Browse workers
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const cityName = cityNames.get(worker.city_id) ?? worker.city_id;
+  const categoryName = worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : 'General labour';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title={`${worker.display_name} - ${worker.headline} | Okanagan Trades`}
+        description={worker.bio.slice(0, 155)}
+        path={`/workers/${worker.id}`}
+        image={worker.photo_url ?? undefined}
+      />
+
+      <div className="mx-auto max-w-[86rem] px-4 sm:px-6 lg:px-10">
+        <Link
+          to="/workers"
+          className="inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500 transition-colors hover:text-zinc-900"
+        >
+          <ArrowRight className="h-3.5 w-3.5 rotate-180" />
+          Back to workers
+        </Link>
+
+        <div className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
+          <div>
+            <div className="overflow-hidden border border-zinc-200 bg-white shadow-sm">
+              <div className="relative aspect-[16/9] w-full overflow-hidden bg-zinc-100">
+                {worker.photo_url ? (
+                  <img src={worker.photo_url} alt={worker.display_name} className="h-full w-full object-cover" />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-zinc-300">
+                    <UserRound className="h-24 w-24" strokeWidth={1.2} />
+                  </div>
+                )}
+              </div>
+              <div className="p-6 sm:p-8">
+                <div className="flex flex-wrap gap-2">
+                  <span className="inline-flex items-center gap-2 border border-orange-200 bg-orange-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-orange-700">
+                    <CalendarClock className="h-3.5 w-3.5" />
+                    {availabilityLabel(worker.availability)}
+                  </span>
+                  {worker.years_experience !== null ? (
+                    <span className="inline-flex items-center border border-zinc-200 bg-zinc-50 px-3 py-1.5 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-zinc-600">
+                      {worker.years_experience} yr{worker.years_experience === 1 ? '' : 's'} experience
+                    </span>
+                  ) : null}
+                </div>
+
+                <h1 className="mt-5 text-4xl font-bold leading-tight text-zinc-950">{worker.display_name}</h1>
+                <p className="mt-2 text-lg font-semibold text-zinc-700">{worker.headline}</p>
+
+                <div className="mt-5 grid gap-3 text-sm text-zinc-600 sm:grid-cols-2">
+                  <div className="flex items-center gap-2"><Hammer className="h-4 w-4 text-zinc-400" />{categoryName}</div>
+                  <div className="flex items-center gap-2"><MapPin className="h-4 w-4 text-zinc-400" />{cityName}</div>
+                </div>
+
+                <p className="mt-6 whitespace-pre-line text-base leading-7 text-zinc-700">{worker.bio}</p>
+
+                {worker.skills.length > 0 ? (
+                  <div className="mt-6">
+                    <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Skills</p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {worker.skills.map((skill) => (
+                        <span key={skill} className="inline-flex items-center border border-zinc-200 bg-zinc-50 px-3 py-1.5 text-sm text-zinc-700">
+                          {skill}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {worker.service_areas.length > 0 ? (
+                  <div className="mt-6">
+                    <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Service areas</p>
+                    <p className="mt-2 text-sm text-zinc-700">{worker.service_areas.join(', ')}</p>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <aside className="border border-zinc-200 bg-white p-6 shadow-sm lg:sticky lg:top-24">
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Rate</p>
+            <p className="mt-2 text-2xl font-bold text-zinc-950">{worker.rate_label ?? 'Negotiable'}</p>
+
+            <div className="mt-6 border-t border-zinc-100 pt-6">
+              <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-500">Contact</p>
+              <p className="mt-2 font-semibold text-zinc-900">{worker.contact_name}</p>
+              <div className="mt-4 flex flex-col gap-2">
+                {worker.contact_phone ? (
+                  <a
+                    href={`tel:${worker.contact_phone}`}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-900 bg-zinc-900 px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-white transition-colors hover:bg-zinc-800"
+                  >
+                    <Phone className="h-4 w-4" />
+                    Call
+                  </a>
+                ) : null}
+                {worker.contact_email ? (
+                  <a
+                    href={`mailto:${worker.contact_email}`}
+                    className="inline-flex min-h-11 items-center justify-center gap-2 border border-zinc-200 bg-white px-4 py-3 font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-zinc-700 transition-colors hover:border-zinc-900 hover:text-zinc-950"
+                  >
+                    <Mail className="h-4 w-4" />
+                    Email
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/pages/WorkerProfilePage.tsx
+++ b/src/pages/WorkerProfilePage.tsx
@@ -69,7 +69,7 @@ export default function WorkerProfilePage() {
     );
   }
 
-  if (error || !worker || worker.status !== 'approved') {
+  if (error || !worker || worker.status !== 'approved' || !worker.open_to_work) {
     return (
       <div className="min-h-screen bg-[#FAFAFA] px-4 py-24 font-sans text-zinc-900">
         <Seo title="Worker not found | Okanagan Trades" description="This worker profile is unavailable." path="/workers" robots="noindex,follow" />

--- a/src/pages/WorkersPage.tsx
+++ b/src/pages/WorkersPage.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AlertCircle, ArrowRight, Search, UserRound } from 'lucide-react';
+import { motion } from 'motion/react';
+
+import SectionEyebrow from '@/src/components/SectionEyebrow';
+import Seo from '@/src/components/Seo';
+import WorkerCard from '@/src/components/WorkerCard';
+import { useDirectoryData } from '@/src/directory-data';
+import {
+  type WorkerAvailability,
+  type WorkerProfile,
+  fetchApprovedWorkerProfiles,
+} from '@/src/lib/workerProfiles';
+
+const availabilityOptions: Array<{ value: '' | WorkerAvailability; label: string }> = [
+  { value: '', label: 'Any availability' },
+  { value: 'on_demand', label: 'On-demand' },
+  { value: 'short_term', label: 'Short-term' },
+  { value: 'full_time', label: 'Full-time' },
+];
+
+export default function WorkersPage() {
+  const { cities, categories, isLoading: directoryLoading } = useDirectoryData();
+  const [workers, setWorkers] = useState<WorkerProfile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cityFilter, setCityFilter] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState('');
+  const [availabilityFilter, setAvailabilityFilter] = useState<'' | WorkerAvailability>('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const cityNames = useMemo(() => new Map(cities.map((city) => [city.id, city.name])), [cities]);
+  const categoryNames = useMemo(
+    () => new Map(categories.map((category) => [category.id, category.name])),
+    [categories],
+  );
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function loadWorkers() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchApprovedWorkerProfiles();
+        if (isActive) {
+          setWorkers(data);
+        }
+      } catch (caughtError) {
+        if (isActive) {
+          setError(caughtError instanceof Error ? caughtError.message : 'Unable to load worker profiles.');
+        }
+      } finally {
+        if (isActive) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadWorkers();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  const filteredWorkers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return workers
+      .filter((worker) => !cityFilter || worker.city_id === cityFilter)
+      .filter((worker) => !categoryFilter || worker.category_id === categoryFilter)
+      .filter((worker) => !availabilityFilter || worker.availability === availabilityFilter)
+      .filter((worker) => {
+        if (!query) return true;
+        return [
+          worker.display_name,
+          worker.headline,
+          worker.bio,
+          worker.rate_label ?? '',
+          worker.skills.join(' '),
+          cityNames.get(worker.city_id) ?? worker.city_id,
+          worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : '',
+        ].some((value) => value.toLowerCase().includes(query));
+      });
+  }, [availabilityFilter, categoryFilter, categoryNames, cityFilter, cityNames, searchQuery, workers]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.45 }}
+      className="min-h-screen bg-[#FAFAFA] py-24 font-sans text-zinc-900"
+    >
+      <Seo
+        title="Okanagan Trades Workers | Hire Local Tradespeople"
+        description="Browse verified Okanagan tradespeople and labourers available for work. Filter by trade, city, and availability, then contact them directly."
+        path="/workers"
+        keywords={[
+          'okanagan tradespeople',
+          'kelowna labourers for hire',
+          'okanagan workers available',
+          'hire local trades okanagan',
+        ]}
+      />
+
+      <div className="mx-auto max-w-[96rem] px-4 sm:px-6 lg:px-10">
+        <div className="grid gap-8 border-b border-zinc-200 pb-10 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <div>
+            <SectionEyebrow
+              icon={UserRound}
+              className="inline-flex items-center gap-2 border border-zinc-200 bg-white px-4 py-2 font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-zinc-600 shadow-sm"
+              iconClassName="h-3.5 w-3.5 text-orange-500"
+            >
+              Worker profiles
+            </SectionEyebrow>
+            <h1 className="mt-6 text-4xl font-bold uppercase leading-tight text-zinc-950 sm:text-5xl lg:text-6xl">
+              Hire local tradespeople
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-8 text-zinc-600">
+              Browse verified profiles of Okanagan tradespeople and labourers available for work, then reach out
+              to them directly.
+            </p>
+          </div>
+          <Link
+            to="/worker/start"
+            className="inline-flex min-h-12 items-center justify-center gap-3 border-2 border-zinc-900 bg-zinc-900 px-5 py-4 font-mono text-[10px] font-bold uppercase tracking-[0.16em] text-white shadow-[4px_4px_0px_0px_rgba(24,24,27,1)] transition-all hover:translate-x-0.5 hover:translate-y-0.5 hover:border-orange-500 hover:bg-orange-500 hover:shadow-none"
+          >
+            Create your profile
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+
+        <section className="mt-8 border border-zinc-200 bg-white p-5 shadow-sm sm:p-6">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_repeat(3,minmax(10rem,14rem))]">
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Search</label>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+                <input
+                  type="search"
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Name, skills, trade, or city"
+                  className="w-full border border-zinc-200 bg-zinc-50 px-11 py-4 text-base text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-zinc-900 focus:bg-white"
+                />
+              </div>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">City</label>
+              <select value={cityFilter} onChange={(event) => setCityFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">All cities</option>
+                {cities.map((city) => <option key={city.id} value={city.id}>{city.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Trade</label>
+              <select value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                <option value="">All trades</option>
+                {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="mb-2 block font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-500">Availability</label>
+              <select value={availabilityFilter} onChange={(event) => setAvailabilityFilter(event.target.value as '' | WorkerAvailability)} className="w-full border border-zinc-200 bg-zinc-50 px-4 py-4 text-base text-zinc-900 outline-none focus:border-zinc-900 focus:bg-white">
+                {availabilityOptions.map((option) => <option key={option.value || 'all'} value={option.value}>{option.label}</option>)}
+              </select>
+            </div>
+          </div>
+        </section>
+
+        {error ? (
+          <div className="mt-8 flex items-start gap-3 border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+        ) : null}
+
+        {loading || directoryLoading ? (
+          <div className="mt-10 flex min-h-64 items-center justify-center">
+            <div className="h-12 w-12 animate-spin rounded-full border-2 border-zinc-200 border-t-zinc-900"></div>
+          </div>
+        ) : (
+          <section className="mt-8">
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <h2 className="text-2xl font-bold text-zinc-950">{filteredWorkers.length} available</h2>
+              <p className="hidden font-mono text-[10px] font-bold uppercase tracking-[0.18em] text-zinc-400 sm:block">Approved profiles only</p>
+            </div>
+
+            {filteredWorkers.length === 0 ? (
+              <div className="border border-zinc-200 bg-white px-6 py-12 text-center shadow-sm">
+                <p className="text-lg font-semibold text-zinc-950">No worker profiles match these filters.</p>
+                <p className="mt-2 text-sm text-zinc-500">Create a profile and it will appear here after admin review.</p>
+              </div>
+            ) : (
+              <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {filteredWorkers.map((worker) => (
+                  <div key={worker.id} className="h-full">
+                    <WorkerCard
+                      worker={worker}
+                      cityName={cityNames.get(worker.city_id) ?? worker.city_id}
+                      categoryName={worker.category_id ? categoryNames.get(worker.category_id) ?? worker.category_id : 'General labour'}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/supabase/functions/parse_resume/index.ts
+++ b/supabase/functions/parse_resume/index.ts
@@ -1,0 +1,211 @@
+import { serve } from 'https://deno.land/std@0.177.0/http/server.ts';
+
+const geminiApiKey = Deno.env.get('GEMINI_API_KEY') ?? Deno.env.get('GOOGLE_API_KEY');
+
+const GEMINI_MODEL = 'gemini-2.5-flash';
+const MAX_TEXT_LENGTH = 40_000;
+const MAX_BASE64_LENGTH = 8_000_000; // ~6MB binary
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+interface AllowedRef {
+  id: string;
+  name: string;
+}
+
+interface ParseRequest {
+  text?: string;
+  fileBase64?: string;
+  mimeType?: string;
+  categories?: AllowedRef[];
+  cities?: AllowedRef[];
+}
+
+interface ResumeDraft {
+  display_name: string | null;
+  headline: string | null;
+  category_id: string | null;
+  city_id: string | null;
+  skills: string[];
+  years_experience: number | null;
+  bio: string | null;
+  service_areas: string[];
+  rate_label: string | null;
+  contact_email: string | null;
+  contact_phone: string | null;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function buildInstruction(categories: AllowedRef[], cities: AllowedRef[]) {
+  const categoryList = categories.map((c) => `${c.id} = ${c.name}`).join('\n');
+  const cityList = cities.map((c) => `${c.id} = ${c.name}`).join('\n');
+
+  return [
+    'You extract a tradesperson worker profile from a resume for a local trades directory.',
+    'Use ONLY facts present in the resume. Do not invent skills, certifications, employers, or contact info.',
+    '',
+    'Return a single JSON object with exactly these keys:',
+    '{',
+    '  "display_name": string|null,        // the person\'s name',
+    '  "headline": string|null,            // <=140 chars, e.g. "Red Seal carpenter, 8 yrs framing"',
+    '  "category_id": string|null,         // MUST be one of the allowed trade ids below, else null',
+    '  "city_id": string|null,             // MUST be one of the allowed city ids below, else null',
+    '  "skills": string[],                 // short skill/ticket keywords',
+    '  "years_experience": number|null,    // integer years, inferred from history',
+    '  "bio": string|null,                 // 2-4 sentence first-person summary built only from the resume',
+    '  "service_areas": string[],          // place names mentioned, if any',
+    '  "rate_label": string|null,          // pay/rate only if explicitly stated',
+    '  "contact_email": string|null,',
+    '  "contact_phone": string|null',
+    '}',
+    '',
+    'Allowed trade ids (pick the closest match or null):',
+    categoryList || '(none provided)',
+    '',
+    'Allowed city ids (pick the closest match or null):',
+    cityList || '(none provided)',
+    '',
+    'Never output a category_id or city_id that is not in the lists above. Output JSON only.',
+  ].join('\n');
+}
+
+function coerceDraft(raw: unknown, categories: AllowedRef[], cities: AllowedRef[]): ResumeDraft {
+  const obj = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const categoryIds = new Set(categories.map((c) => c.id));
+  const cityIds = new Set(cities.map((c) => c.id));
+
+  const asString = (value: unknown): string | null => {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+  const asStringArray = (value: unknown): string[] => {
+    if (!Array.isArray(value)) return [];
+    return value.map((entry) => (typeof entry === 'string' ? entry.trim() : '')).filter(Boolean).slice(0, 30);
+  };
+  const asYears = (value: unknown): number | null => {
+    const n = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(n) || n < 0) return null;
+    return Math.min(70, Math.round(n));
+  };
+
+  const categoryId = asString(obj.category_id);
+  const cityId = asString(obj.city_id);
+
+  return {
+    display_name: asString(obj.display_name),
+    headline: asString(obj.headline)?.slice(0, 140) ?? null,
+    category_id: categoryId && categoryIds.has(categoryId) ? categoryId : null,
+    city_id: cityId && cityIds.has(cityId) ? cityId : null,
+    skills: asStringArray(obj.skills),
+    years_experience: asYears(obj.years_experience),
+    bio: asString(obj.bio),
+    service_areas: asStringArray(obj.service_areas),
+    rate_label: asString(obj.rate_label),
+    contact_email: asString(obj.contact_email),
+    contact_phone: asString(obj.contact_phone),
+  };
+}
+
+function extractJsonObject(text: string): unknown {
+  const fenced = text.trim().match(/```(?:json)?\s*([\s\S]*?)```/i)?.[1];
+  const candidate = fenced ?? text;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error('No JSON object found in model output.');
+  }
+  return JSON.parse(candidate.slice(start, end + 1));
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ success: false, error: 'Method not allowed' }, 405);
+  }
+
+  if (!geminiApiKey) {
+    return jsonResponse({ success: false, error: 'Resume parsing is not configured.' }, 503);
+  }
+
+  let payload: ParseRequest;
+  try {
+    payload = await req.json();
+  } catch {
+    return jsonResponse({ success: false, error: 'Invalid JSON body.' }, 400);
+  }
+
+  const text = typeof payload.text === 'string' ? payload.text.trim() : '';
+  const fileBase64 = typeof payload.fileBase64 === 'string' ? payload.fileBase64 : '';
+  const mimeType = typeof payload.mimeType === 'string' ? payload.mimeType : 'application/pdf';
+  const categories = Array.isArray(payload.categories) ? payload.categories.filter((c) => c?.id && c?.name) : [];
+  const cities = Array.isArray(payload.cities) ? payload.cities.filter((c) => c?.id && c?.name) : [];
+
+  if (!text && !fileBase64) {
+    return jsonResponse({ success: false, error: 'Provide resume text or a file.' }, 400);
+  }
+  if (text.length > MAX_TEXT_LENGTH) {
+    return jsonResponse({ success: false, error: 'Resume text is too long.' }, 413);
+  }
+  if (fileBase64.length > MAX_BASE64_LENGTH) {
+    return jsonResponse({ success: false, error: 'Resume file is too large.' }, 413);
+  }
+
+  const instruction = buildInstruction(categories, cities);
+  const parts: Array<Record<string, unknown>> = [{ text: instruction }];
+  if (fileBase64) {
+    parts.push({ inlineData: { mimeType, data: fileBase64 } });
+  } else {
+    parts.push({ text: `RESUME:\n${text}` });
+  }
+
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${geminiApiKey}`;
+
+  let modelText: string;
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts }],
+        generationConfig: { responseMimeType: 'application/json', temperature: 0.2 },
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.error('Gemini error', response.status, body.slice(0, 500));
+      return jsonResponse({ success: false, error: 'Could not read the resume right now.' }, 502);
+    }
+
+    const data = await response.json();
+    modelText = data?.candidates?.[0]?.content?.parts?.map((p: { text?: string }) => p?.text ?? '').join('') ?? '';
+    if (!modelText.trim()) {
+      throw new Error('Empty model response.');
+    }
+  } catch (error) {
+    console.error('Gemini request failed', error);
+    return jsonResponse({ success: false, error: 'Could not read the resume right now.' }, 502);
+  }
+
+  try {
+    const draft = coerceDraft(extractJsonObject(modelText), categories, cities);
+    return jsonResponse({ success: true, draft });
+  } catch (error) {
+    console.error('Resume parse failed', error);
+    return jsonResponse({ success: false, error: 'Could not understand the resume. Please fill the form manually.' }, 422);
+  }
+});

--- a/supabase/functions/parse_resume/index.ts
+++ b/supabase/functions/parse_resume/index.ts
@@ -175,6 +175,8 @@ serve(async (req) => {
   const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent?key=${geminiApiKey}`;
 
   let modelText: string;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 25_000);
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -183,11 +185,12 @@ serve(async (req) => {
         contents: [{ role: 'user', parts }],
         generationConfig: { responseMimeType: 'application/json', temperature: 0.2 },
       }),
+      signal: controller.signal,
     });
 
     if (!response.ok) {
-      const body = await response.text();
-      console.error('Gemini error', response.status, body.slice(0, 500));
+      // Log only the status — the response body can echo resume content (PII).
+      console.error('Gemini error status', response.status);
       return jsonResponse({ success: false, error: 'Could not read the resume right now.' }, 502);
     }
 
@@ -197,8 +200,11 @@ serve(async (req) => {
       throw new Error('Empty model response.');
     }
   } catch (error) {
-    console.error('Gemini request failed', error);
+    // Avoid logging the error object (may include request/response with PII).
+    console.error('Gemini request failed:', error instanceof Error ? error.name : 'unknown');
     return jsonResponse({ success: false, error: 'Could not read the resume right now.' }, 502);
+  } finally {
+    clearTimeout(timeout);
   }
 
   try {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -962,6 +962,8 @@ create table if not exists public.worker_profiles (
   years_experience integer check (years_experience is null or years_experience >= 0),
   bio text not null,
   photo_url text,
+  resume_path text,
+  open_to_work boolean not null default true,
   contact_name text not null,
   contact_email text,
   contact_phone text,
@@ -999,6 +1001,34 @@ begin
     return new;
   end if;
 
+  -- Allow a non-admin to flip the open_to_work visibility toggle without
+  -- re-entering moderation: only force re-review when public-facing content
+  -- actually changed.
+  if tg_op = 'update' and not (
+       new.display_name      is distinct from old.display_name
+    or new.headline          is distinct from old.headline
+    or new.city_id           is distinct from old.city_id
+    or new.category_id       is distinct from old.category_id
+    or new.availability      is distinct from old.availability
+    or new.service_areas     is distinct from old.service_areas
+    or new.skills            is distinct from old.skills
+    or new.rate_label        is distinct from old.rate_label
+    or new.years_experience  is distinct from old.years_experience
+    or new.bio               is distinct from old.bio
+    or new.photo_url         is distinct from old.photo_url
+    or new.resume_path       is distinct from old.resume_path
+    or new.contact_name      is distinct from old.contact_name
+    or new.contact_email     is distinct from old.contact_email
+    or new.contact_phone     is distinct from old.contact_phone
+  ) then
+    -- Only open_to_work (and/or system columns) changed: preserve review state.
+    new.status := old.status;
+    new.reviewed_by := old.reviewed_by;
+    new.reviewed_at := old.reviewed_at;
+    new.rejection_reason := old.rejection_reason;
+    return new;
+  end if;
+
   new.status := 'pending';
   new.reviewed_by := null;
   new.reviewed_at := null;
@@ -1020,7 +1050,7 @@ create policy "worker_profiles_select_public_approved"
 on public.worker_profiles
 for select
 to anon, authenticated
-using (status = 'approved');
+using (status = 'approved' and open_to_work);
 
 drop policy if exists "worker_profiles_select_self" on public.worker_profiles;
 create policy "worker_profiles_select_self"
@@ -1150,6 +1180,10 @@ on storage.objects
 for update
 to authenticated
 using (
+  bucket_id = 'worker-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+)
+with check (
   bucket_id = 'worker-photos'
   and (storage.foldername(name))[1] = auth.uid()::text
 );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -172,6 +172,11 @@ create table if not exists public.classifieds (
   constraint classifieds_contact_method_check check (
     nullif(btrim(coalesce(contact_email, '')), '') is not null
     or nullif(btrim(coalesce(contact_phone, '')), '') is not null
+  ),
+  constraint classifieds_date_range_check check (
+    start_date is null
+    or end_date is null
+    or end_date >= start_date
   )
 );
 
@@ -208,6 +213,20 @@ begin
       add constraint business_claims_notification_retry_count_check
       check (notification_retry_count >= 0);
   end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'classifieds_date_range_check'
+  ) then
+    alter table public.classifieds
+      add constraint classifieds_date_range_check
+      check (
+        start_date is null
+        or end_date is null
+        or end_date >= start_date
+      );
+  end if;
 end
 $$;
 
@@ -229,6 +248,9 @@ create index if not exists classifieds_city_id_idx on public.classifieds (city_i
 create index if not exists classifieds_category_id_idx on public.classifieds (category_id);
 create index if not exists classifieds_duration_type_idx on public.classifieds (duration_type);
 create index if not exists classifieds_created_at_idx on public.classifieds (created_at desc);
+create index if not exists classifieds_public_jobs_idx
+  on public.classifieds (status, expires_at, created_at desc)
+  where kind = 'job';
 
 create unique index if not exists business_claims_one_pending_per_user_business_idx
   on public.business_claims (user_id, business_id)
@@ -448,10 +470,12 @@ on public.classifieds
 for insert
 to anon, authenticated
 with check (
-  status = 'pending'
+  kind = 'job'
+  and status = 'pending'
   and reviewed_by is null
   and reviewed_at is null
   and rejection_reason is null
+  and expires_at > now()
   and (
     nullif(btrim(coalesce(contact_email, '')), '') is not null
     or nullif(btrim(coalesce(contact_phone, '')), '') is not null
@@ -765,6 +789,10 @@ begin
   set status = p_status,
       reviewed_by = auth.uid(),
       reviewed_at = now(),
+      expires_at = case
+        when p_status = 'approved' then now() + interval '45 days'
+        else expires_at
+      end,
       rejection_reason = case
         when p_status = 'rejected' then p_rejection_reason
         when p_status = 'approved' then null

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -147,6 +147,34 @@ create table if not exists public.business_overrides (
   updated_at timestamptz not null default now()
 );
 
+create table if not exists public.classifieds (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null check (kind in ('job', 'worker')),
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected', 'archived')),
+  title text not null,
+  description text not null,
+  city_id text not null references public.cities (id),
+  category_id text references public.categories (id),
+  duration_type text not null check (duration_type in ('on_demand', 'short_term', 'full_time')),
+  organization_name text,
+  compensation_label text,
+  start_date date,
+  end_date date,
+  contact_name text not null,
+  contact_email text,
+  contact_phone text,
+  reviewed_by uuid references public.profiles (id),
+  reviewed_at timestamptz,
+  rejection_reason text,
+  expires_at timestamptz not null default now() + interval '45 days',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint classifieds_contact_method_check check (
+    nullif(btrim(coalesce(contact_email, '')), '') is not null
+    or nullif(btrim(coalesce(contact_phone, '')), '') is not null
+  )
+);
+
 alter table public.business_overrides add column if not exists name text;
 alter table public.business_claims add column if not exists evidence_urls text[] not null default '{}';
 alter table public.business_claims add column if not exists notification_status text not null default 'pending';
@@ -195,6 +223,13 @@ create index if not exists business_claims_user_id_idx on public.business_claims
 create index if not exists business_claims_business_id_idx on public.business_claims (business_id);
 create index if not exists business_claims_notification_status_idx on public.business_claims (notification_status);
 
+create index if not exists classifieds_status_idx on public.classifieds (status);
+create index if not exists classifieds_kind_idx on public.classifieds (kind);
+create index if not exists classifieds_city_id_idx on public.classifieds (city_id);
+create index if not exists classifieds_category_id_idx on public.classifieds (category_id);
+create index if not exists classifieds_duration_type_idx on public.classifieds (duration_type);
+create index if not exists classifieds_created_at_idx on public.classifieds (created_at desc);
+
 create unique index if not exists business_claims_one_pending_per_user_business_idx
   on public.business_claims (user_id, business_id)
   where status = 'pending';
@@ -218,6 +253,12 @@ execute function public.set_updated_at();
 drop trigger if exists business_overrides_set_updated_at on public.business_overrides;
 create trigger business_overrides_set_updated_at
 before update on public.business_overrides
+for each row
+execute function public.set_updated_at();
+
+drop trigger if exists classifieds_set_updated_at on public.classifieds;
+create trigger classifieds_set_updated_at
+before update on public.classifieds
 for each row
 execute function public.set_updated_at();
 
@@ -281,6 +322,7 @@ execute function public.protect_profile_admin_fields();
 alter table public.profiles enable row level security;
 alter table public.business_claims enable row level security;
 alter table public.business_overrides enable row level security;
+alter table public.classifieds enable row level security;
 
 drop policy if exists "profiles_select_self" on public.profiles;
 create policy "profiles_select_self"
@@ -392,6 +434,44 @@ using (
       and bc.status = 'approved'
   )
 );
+
+drop policy if exists "classifieds_select_public_approved" on public.classifieds;
+create policy "classifieds_select_public_approved"
+on public.classifieds
+for select
+to anon, authenticated
+using (status = 'approved' and expires_at > now());
+
+drop policy if exists "classifieds_insert_public_pending" on public.classifieds;
+create policy "classifieds_insert_public_pending"
+on public.classifieds
+for insert
+to anon, authenticated
+with check (
+  status = 'pending'
+  and reviewed_by is null
+  and reviewed_at is null
+  and rejection_reason is null
+  and (
+    nullif(btrim(coalesce(contact_email, '')), '') is not null
+    or nullif(btrim(coalesce(contact_phone, '')), '') is not null
+  )
+);
+
+drop policy if exists "classifieds_select_admin" on public.classifieds;
+create policy "classifieds_select_admin"
+on public.classifieds
+for select
+to authenticated
+using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
+
+drop policy if exists "classifieds_update_admin" on public.classifieds;
+create policy "classifieds_update_admin"
+on public.classifieds
+for update
+to authenticated
+using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'))
+with check (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
 
 create or replace function public.submit_business_claim(
   p_business_id text,
@@ -647,6 +727,65 @@ begin
 end;
 $$;
 
+create or replace function public.review_classified(
+  p_classified_id uuid,
+  p_status text,
+  p_rejection_reason text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1
+    from public.profiles
+    where id = auth.uid() and role = 'admin'
+  ) then
+    raise exception using
+      sqlstate = 'P1020',
+      message = 'Not authorized';
+  end if;
+
+  if p_status not in ('approved', 'rejected', 'archived') then
+    raise exception using
+      sqlstate = 'P1021',
+      message = 'Invalid status';
+  end if;
+
+  if p_status = 'rejected'
+     and nullif(btrim(coalesce(p_rejection_reason, '')), '') is null then
+    raise exception using
+      sqlstate = 'P1022',
+      message = 'Rejection reason required';
+  end if;
+
+  update public.classifieds
+  set status = p_status,
+      reviewed_by = auth.uid(),
+      reviewed_at = now(),
+      rejection_reason = case
+        when p_status = 'rejected' then p_rejection_reason
+        when p_status = 'approved' then null
+        else rejection_reason
+      end
+  where id = p_classified_id;
+
+  if not found then
+    raise exception using
+      sqlstate = 'P1023',
+      message = 'Classified not found';
+  end if;
+end;
+$$;
+
+grant execute on function public.review_classified(
+  uuid,
+  text,
+  text
+) to authenticated;
+
 create or replace view public.verified_businesses as
 select distinct business_id
 from public.business_claims
@@ -803,3 +942,302 @@ on public.call_requests
 for select
 to authenticated
 using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
+
+-- =====================================================================
+-- Worker profiles: persistent, account-linked tradesperson profiles
+-- =====================================================================
+
+create table if not exists public.worker_profiles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null unique references public.profiles (id) on delete cascade,
+  status text not null default 'pending' check (status in ('pending', 'approved', 'rejected', 'archived')),
+  display_name text not null,
+  headline text not null,
+  city_id text not null references public.cities (id),
+  category_id text references public.categories (id),
+  availability text not null check (availability in ('on_demand', 'short_term', 'full_time')),
+  service_areas text[] not null default '{}',
+  skills jsonb not null default '[]'::jsonb,
+  rate_label text,
+  years_experience integer check (years_experience is null or years_experience >= 0),
+  bio text not null,
+  photo_url text,
+  contact_name text not null,
+  contact_email text,
+  contact_phone text,
+  reviewed_by uuid references public.profiles (id),
+  reviewed_at timestamptz,
+  rejection_reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint worker_profiles_contact_method_check check (
+    nullif(btrim(coalesce(contact_email, '')), '') is not null
+    or nullif(btrim(coalesce(contact_phone, '')), '') is not null
+  )
+);
+
+create index if not exists worker_profiles_status_idx on public.worker_profiles (status);
+create index if not exists worker_profiles_city_id_idx on public.worker_profiles (city_id);
+create index if not exists worker_profiles_category_id_idx on public.worker_profiles (category_id);
+create index if not exists worker_profiles_availability_idx on public.worker_profiles (availability);
+create index if not exists worker_profiles_created_at_idx on public.worker_profiles (created_at desc);
+
+drop trigger if exists worker_profiles_set_updated_at on public.worker_profiles;
+create trigger worker_profiles_set_updated_at
+before update on public.worker_profiles
+for each row
+execute function public.set_updated_at();
+
+-- Force every non-admin write back into the moderation queue so a worker
+-- cannot self-approve, and any edit re-enters review with cleared metadata.
+create or replace function public.enforce_worker_profile_moderation()
+returns trigger
+language plpgsql
+as $$
+begin
+  if exists (select 1 from public.profiles where id = auth.uid() and role = 'admin') then
+    return new;
+  end if;
+
+  new.status := 'pending';
+  new.reviewed_by := null;
+  new.reviewed_at := null;
+  new.rejection_reason := null;
+  return new;
+end;
+$$;
+
+drop trigger if exists worker_profiles_enforce_moderation on public.worker_profiles;
+create trigger worker_profiles_enforce_moderation
+before insert or update on public.worker_profiles
+for each row
+execute function public.enforce_worker_profile_moderation();
+
+alter table public.worker_profiles enable row level security;
+
+drop policy if exists "worker_profiles_select_public_approved" on public.worker_profiles;
+create policy "worker_profiles_select_public_approved"
+on public.worker_profiles
+for select
+to anon, authenticated
+using (status = 'approved');
+
+drop policy if exists "worker_profiles_select_self" on public.worker_profiles;
+create policy "worker_profiles_select_self"
+on public.worker_profiles
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists "worker_profiles_insert_self" on public.worker_profiles;
+create policy "worker_profiles_insert_self"
+on public.worker_profiles
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists "worker_profiles_update_self" on public.worker_profiles;
+create policy "worker_profiles_update_self"
+on public.worker_profiles
+for update
+to authenticated
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists "worker_profiles_select_admin" on public.worker_profiles;
+create policy "worker_profiles_select_admin"
+on public.worker_profiles
+for select
+to authenticated
+using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
+
+drop policy if exists "worker_profiles_update_admin" on public.worker_profiles;
+create policy "worker_profiles_update_admin"
+on public.worker_profiles
+for update
+to authenticated
+using (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'))
+with check (exists (select 1 from public.profiles where id = auth.uid() and role = 'admin'));
+
+create or replace function public.review_worker_profile(
+  p_profile_id uuid,
+  p_status text,
+  p_rejection_reason text default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if not exists (
+    select 1
+    from public.profiles
+    where id = auth.uid() and role = 'admin'
+  ) then
+    raise exception using
+      sqlstate = 'P1030',
+      message = 'Not authorized';
+  end if;
+
+  if p_status not in ('approved', 'rejected', 'archived') then
+    raise exception using
+      sqlstate = 'P1031',
+      message = 'Invalid status';
+  end if;
+
+  if p_status = 'rejected'
+     and nullif(btrim(coalesce(p_rejection_reason, '')), '') is null then
+    raise exception using
+      sqlstate = 'P1032',
+      message = 'Rejection reason required';
+  end if;
+
+  update public.worker_profiles
+  set status = p_status,
+      reviewed_by = auth.uid(),
+      reviewed_at = now(),
+      rejection_reason = case
+        when p_status = 'rejected' then p_rejection_reason
+        when p_status = 'approved' then null
+        else rejection_reason
+      end
+  where id = p_profile_id;
+
+  if not found then
+    raise exception using
+      sqlstate = 'P1033',
+      message = 'Worker profile not found';
+  end if;
+end;
+$$;
+
+grant execute on function public.review_worker_profile(
+  uuid,
+  text,
+  text
+) to authenticated;
+
+-- Public storage bucket for worker profile photos
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'worker-photos',
+  'worker-photos',
+  true,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update
+set
+  public = true,
+  file_size_limit = 5242880,
+  allowed_mime_types = array['image/jpeg', 'image/png', 'image/webp'];
+
+-- Workers upload/replace/delete only inside their own {user_id}/ folder
+drop policy if exists "worker_photos_upload_own" on storage.objects;
+create policy "worker_photos_upload_own"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'worker-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "worker_photos_update_own" on storage.objects;
+create policy "worker_photos_update_own"
+on storage.objects
+for update
+to authenticated
+using (
+  bucket_id = 'worker-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "worker_photos_delete_own" on storage.objects;
+create policy "worker_photos_delete_own"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'worker-photos'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Anyone can read worker photos (public bucket)
+drop policy if exists "worker_photos_read_public" on storage.objects;
+create policy "worker_photos_read_public"
+on storage.objects
+for select
+to anon, authenticated
+using (bucket_id = 'worker-photos');
+
+-- =====================================================================
+-- Resume onboarding: raw resume storage + extra worker_profiles columns
+-- =====================================================================
+
+alter table public.worker_profiles add column if not exists resume_path text;
+alter table public.worker_profiles add column if not exists open_to_work boolean not null default true;
+
+create index if not exists worker_profiles_open_to_work_idx on public.worker_profiles (open_to_work);
+
+-- Private storage bucket for uploaded resumes (admin-readable for moderation)
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'resumes',
+  'resumes',
+  false,
+  10485760,
+  array[
+    'application/pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ]
+)
+on conflict (id) do update
+set
+  public = false,
+  file_size_limit = 10485760,
+  allowed_mime_types = array[
+    'application/pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  ];
+
+drop policy if exists "resumes_upload_own" on storage.objects;
+create policy "resumes_upload_own"
+on storage.objects
+for insert
+to authenticated
+with check (
+  bucket_id = 'resumes'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "resumes_read_own" on storage.objects;
+create policy "resumes_read_own"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'resumes'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "resumes_delete_own" on storage.objects;
+create policy "resumes_delete_own"
+on storage.objects
+for delete
+to authenticated
+using (
+  bucket_id = 'resumes'
+  and (storage.foldername(name))[1] = auth.uid()::text
+);
+
+drop policy if exists "resumes_read_admin" on storage.objects;
+create policy "resumes_read_admin"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'resumes'
+  and exists (select 1 from public.profiles where id = auth.uid() and role = 'admin')
+);


### PR DESCRIPTION
@
## Summary

Consolidates the trades **worker/jobs marketplace** into a single PR on top of the latest `main`. Supersedes the open classifieds PR (#69) by folding it in and building on top.

### Jobs board (evolves the moderated classifieds)
- Job-only posting flow at `/jobs`, `/jobs/post`, `/jobs/submitted`; `/classifieds*` now redirect to `/jobs*` for SEO continuity.
- Anyone can post (no login), admin-moderated, direct phone/email contact.

### Worker profiles (new, account-linked)
- Public browse `/workers`, detail `/workers/:id`, owner dashboard `/worker/dashboard`, admin moderation `/admin/workers`.
- New `worker_profiles` table with RLS, a re-moderation trigger (edits re-enter the queue), `review_worker_profile` RPC, and a public `worker-photos` bucket.
- `open_to_work` toggle controls visibility without deleting the profile.

### Resume onboarding (`/worker/start`)
- Upload **PDF/DOCX** or paste text. A Gemini-backed `parse_resume` edge function extracts a profile draft, **grounded** to valid trade/city IDs.
- Short fixed wizard fills the gaps (availability, city, rate, contact); sign in once (Google / magic link / password) to publish.
- Draft survives the auth redirect via `sessionStorage` + IndexedDB; raw resume stored in a **private `resumes` bucket** for admin review.

## Notes / follow-ups
- **Storage buckets** (`worker-photos`, `resumes`) are defined in `schema.sql` as idempotent SQL; `main` manages buckets outside the repo, so confirm they exist after applying. The out-of-scope `claims` bucket was intentionally not re-added.
- **Deploy steps:** apply `supabase/schema.sql`; `supabase functions deploy parse_resume`; `supabase secrets set GEMINI_API_KEY=...` (parsing runs logged-out, so disable `verify_jwt` for `parse_resume` if the project default blocks anon).
- Verified locally: `npx tsc --noEmit` clean; resume parsing tested end-to-end against Gemini (PDF + text) with correct ID grounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched the Jobs classifieds experience: browse approved jobs, post jobs, and view a submission pending-approval confirmation.
  * Added Workers directory, individual worker profiles, and a worker dashboard for creating/editing profiles.
  * Introduced a multi-step worker onboarding flow with AI resume parsing and resume import persisted across redirects.
  * Added admin moderation pages for both job listings and worker profiles, including approve/reject/archive workflows.
  * Updated site navigation and business links to include Jobs and Workers.
* **Chores**
  * Added a document parsing dependency to support client-side resume conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->